### PR TITLE
Fix <T>  empty tail and other assorted rfc xml parser errors

### DIFF
--- a/npt/parser_rfc_xml.py
+++ b/npt/parser_rfc_xml.py
@@ -289,7 +289,7 @@ def parse_t(xmlElement: ET.Element) -> rfc.T:
             content.append(parse_xref(child))
         if child.tail is not None:
             content.append(rfc.Text(child.tail))
-    if xmlElement.tail is not None:
+    if xmlElement.tail is not None and len(xmlElement.tail.strip()) != 0:
         content.append(rfc.Text(xmlElement.tail))
     return rfc.T(content,
                  xmlElement.attrib.get("anchor"),

--- a/npt/parser_rfc_xml.py
+++ b/npt/parser_rfc_xml.py
@@ -1154,7 +1154,7 @@ def parse_seriesinfo(xmlElement: ET.Element) -> rfc.SeriesInfo:
                           xmlElement.attrib["value"],
                           xmlElement.attrib["name"],
                           xmlElement.attrib.get("status", None),
-                          xmlElement.attrib.get("stream", None),
+                          xmlElement.attrib.get("stream", "IETF"),
                           xmlElement.attrib["value"])
 
 

--- a/npt/parser_rfc_xml.py
+++ b/npt/parser_rfc_xml.py
@@ -1414,7 +1414,7 @@ def parse_rfc(xmlElement: ET.Element) -> rfc.RFC:
                    xmlElement.attrib.get("sortRefs") == "true",
                    xmlElement.attrib.get("submissionType", "IETF"),
                    not xmlElement.attrib.get("symRefs") == "false",
-                   xmlElement.attrib.get("tocDepth"),
+                   xmlElement.attrib.get("tocDepth", "3"),
                    not xmlElement.attrib.get("tocInclude") == "false",
                    xmlElement.attrib.get("updates"),
                    xmlElement.attrib.get("version"))

--- a/npt/parser_rfc_xml.py
+++ b/npt/parser_rfc_xml.py
@@ -94,7 +94,7 @@ def parse_xref(xmlElement: ET.Element) -> rfc.XRef:
     if xmlElement.text is not None:
         text = rfc.Text(xmlElement.text)
     return rfc.XRef(text,
-                    xmlElement.attrib.get("format"),
+                    xmlElement.attrib.get("format", "default"),
                     xmlElement.attrib.get("pageno") == "true",
                     xmlElement.attrib["target"])
 

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -2322,7 +2322,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[0].content[6].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[0].content[6].content[1].content)
-        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
         self.assertEqual( middle.content[0].content[6].content[1].format, "default")
         self.assertFalse( middle.content[0].content[6].content[1].pageno)
         self.assertEqual( middle.content[0].content[6].content[1].target, "ABNF")
@@ -2609,7 +2608,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1], rfc.DD)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content, list)
-        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
         self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content), 3)
         # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[0] <T> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0], rfc.T)
@@ -2632,7 +2630,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[0].keepWithPrevious)
 
         # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[1] <T> 
-        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1], rfc.T)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1], rfc.T): # type-check
             return
@@ -2702,12 +2699,10 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].keepWithPrevious)
 
         # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[2] <T> 
-        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2], rfc.T)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content, list)
-        #FIXME :  class <T> additional line due to newline
         self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[2].content), 5)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text): # type-check
@@ -2768,7 +2763,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>  [1] <DD> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1], rfc.DD)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content, list)
-        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
         self.assertEqual( len(middle.content[1].sections[0].content[3].content[1][1].content), 3)
         # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>  [1] <DD> content[0] <Text> 
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content[0], rfc.Text)
@@ -3053,11 +3047,9 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # sec-01  sub-sec[1] content 
         self.assertIsInstance( middle.content[1].sections[1].content, list)
         self.assertEqual( len(middle.content[1].sections[1].content), 1)
-        # FIXME : Additional element from <T> tail
         self.assertIsInstance( middle.content[1].sections[1].content[0], rfc.T)
         if not isinstance( middle.content[1].sections[1].content[0], rfc.T): # type-check
             return
-        # FIXME : Additional element from <T> tail content
         self.assertIsInstance( middle.content[1].sections[1].content[0].content, list)
         self.assertEqual( len(middle.content[1].sections[1].content[0].content), 11)
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[0], rfc.Text)
@@ -3176,7 +3168,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[0], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[0].content, list)
-        # FIXME : <T> element tail has extra space
         self.assertEqual( len(middle.content[2].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[0].content[0], rfc.Text): # type-check
@@ -3806,7 +3797,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [1] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[1].content, list)
-        # FIXME : <T> extra line in tail
         self.assertEqual( len(middle.content[3].sections[0].content[1].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[1].content[0], rfc.Text): #type-check
@@ -3886,7 +3876,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   PDU names must be unique, both within a document, and across
                   all documents that are linked together (i.e., using the
                   structured language defined in """)
-        # FIXME : <T> extra line in tail
         self.assertIsInstance( middle.content[3].sections[0].content[4].content[1], rfc.XRef)
         if not isinstance( middle.content[3].sections[0].content[4].content[1], rfc.XRef): # type-check
             return

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -1923,6 +1923,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[0].sections[1].content[0].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone(back.sections[0].sections[1].content[0].content[1].content)
+        # FIXME : should default to "default" RFC7991 2.66.1
         self.assertIsNone(back.sections[0].sections[1].content[0].content[1].format)
         self.assertFalse(back.sections[0].sections[1].content[0].content[1].pageno)
         self.assertEqual(back.sections[0].sections[1].content[0].content[1].target, "augmentedascii")
@@ -1939,6 +1940,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[0].sections[1].content[0].content[3], rfc.XRef): # type-check
             return
         self.assertIsNone(back.sections[0].sections[1].content[0].content[3].content)
+        # FIXME : should default to "default" RFC7991 2.66.1
         self.assertIsNone(back.sections[0].sections[1].content[0].content[3].format)
         self.assertFalse(back.sections[0].sections[1].content[0].content[3].pageno)
         self.assertEqual(back.sections[0].sections[1].content[0].content[3].target, "augmentedascii")
@@ -2085,3 +2087,2358 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertFalse(back.sections[1].removeInRFC)
         self.assertIsNone(back.sections[1].title)
         self.assertEqual(back.sections[1].toc, "default" )
+
+
+    def test_rfc_middle(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+            raw_content = fd.read()
+            xml_tree = ET.fromstring(raw_content)
+            middle = npt.parser_rfc_xml.parse_rfc(xml_tree).middle
+
+        # Test whether the title has been parsed correctly
+        # For now, this just checks that the correct nodes are parsed
+        self.assertEqual(len(middle.content), 8)
+        # sec-00
+        self.assertIsInstance(middle.content[0], rfc.Section)
+
+        # sec-00  name 
+        self.assertIsNotNone( middle.content[0].name) 
+        self.assertIsInstance( middle.content[0].name, rfc.Name)
+        if not isinstance(middle.content[0].name, rfc.Name):
+            return
+        self.assertIsInstance( middle.content[0].name.content, list)
+        self.assertEqual( len(middle.content[0].name.content), 1)
+        self.assertIsInstance( middle.content[0].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[0].name.content[0].content, "Introduction") 
+        # sec-00  content 
+        self.assertIsInstance( middle.content[0].content, list)
+        self.assertEqual( len(middle.content[0].content), 7)
+        # sec-00  content[0] <T> 
+        self.assertIsInstance( middle.content[0].content[0], rfc.T)
+        if not isinstance(middle.content[0].content[0], rfc.T): # type-check
+            return
+        # sec-00  content[0] <T>  Text
+        self.assertIsInstance( middle.content[0].content[0].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[0].content), 2)
+        self.assertIsInstance( middle.content[0].content[0].content[0], rfc.Text)
+        if not isinstance(middle.content[0].content[0].content[0], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[0].content[0].content[0].content, """
+                Packet header diagrams have become a widely used format for
+                describing the syntax of binary protocols. In otherwise largely textual
+                documents, they allow for the visualisation of packet formats, reducing
+                human error, and aiding in the implementation of parsers for the protocols
+                that they specify.
+            """)
+        #FIXME - unnecessary empty tag 
+        self.assertIsInstance(middle.content[0].content[0].content[1], rfc.Text) 
+        if not isinstance(middle.content[0].content[0].content[1], rfc.Text) : # type-check
+            return
+        self.assertEqual(middle.content[0].content[0].content[1].content, """
+            """)
+        # sec-00  content[0] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[0].anchor)
+        self.assertIsNone( middle.content[0].content[0].hangText)
+        self.assertFalse( middle.content[0].content[0].keepWithNext)
+        self.assertFalse( middle.content[0].content[0].keepWithPrevious)
+
+
+        # sec-00  content[1] <T> 
+        self.assertIsInstance( middle.content[0].content[1], rfc.T)
+        if not isinstance( middle.content[0].content[1], rfc.T): # type-check
+            return
+        # sec-00  content[1] <T>  Text
+        self.assertIsInstance( middle.content[0].content[1].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[1].content), 4)
+        self.assertIsInstance( middle.content[0].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[0].content[1].content[0], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[0].content[1].content[0].content, """
+                """)
+        self.assertIsInstance( middle.content[0].content[1].content[1], rfc.XRef)
+        if not isinstance( middle.content[0].content[1].content[1], rfc.XRef):  #type-check
+            return
+        self.assertIsNone( middle.content[0].content[1].content[1].content)
+        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
+        self.assertIsNone( middle.content[0].content[1].content[1].format)
+        self.assertFalse( middle.content[0].content[1].content[1].pageno)
+        self.assertEqual( middle.content[0].content[1].content[1].target, "tcp-header-format")
+        self.assertIsInstance( middle.content[0].content[1].content[2], rfc.Text) 
+        if not isinstance( middle.content[0].content[1].content[2], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[0].content[1].content[2].content, """ gives an example of how packet
+                header diagrams are used to define binary protocol formats. The format
+                has an obvious structure: the diagram clearly delineates each field,
+                showing its width and its position within the header. This type of diagram is
+                designed for human readers, but is consistent enough that it should
+                be possible to develop a tool that generates a parser for the packet
+                format from the diagram.
+
+            """)
+        self.assertIsInstance( middle.content[0].content[1].content[3], rfc.Text) 
+        if not isinstance( middle.content[0].content[1].content[3], rfc.Text) : # type-check
+            return
+        #FIXME - unnecessary empty tag 
+        self.assertEqual( middle.content[0].content[1].content[3].content, """
+        """)
+        # sec-00  content[1] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[1].anchor)
+        self.assertIsNone( middle.content[0].content[1].hangText)
+        self.assertFalse( middle.content[0].content[1].keepWithNext)
+        self.assertFalse( middle.content[0].content[1].keepWithPrevious)
+
+
+
+
+        # sec-00  content[2] <Figure> 
+        self.assertIsInstance( middle.content[0].content[2], rfc.Figure)
+        if not isinstance( middle.content[0].content[2], rfc.Figure): # type-check
+            return
+        # sec-00  content[2] <Figure>  name
+        self.assertIsInstance( middle.content[0].content[2].name, rfc.Name)
+        if not isinstance( middle.content[0].content[2].name, rfc.Name): # type-check
+            return
+        self.assertIsInstance( middle.content[0].content[2].name.content, list)
+        self.assertEqual( len(middle.content[0].content[2].name.content), 2)
+        self.assertIsInstance( middle.content[0].content[2].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[0].content[2].name.content[0].content, "TCP's header format (from ")
+        self.assertIsInstance( middle.content[0].content[2].name.content[1], rfc.XRef)
+        if not isinstance( middle.content[0].content[2].name.content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[0].content[2].name.content[1].content)
+        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
+        self.assertIsNone( middle.content[0].content[2].name.content[1].format)
+        self.assertFalse( middle.content[0].content[2].name.content[1].pageno)
+        self.assertEqual( middle.content[0].content[2].name.content[1].target, "RFC793")
+        # sec-00  content[2] <Figure>  irefs
+        self.assertIsInstance( middle.content[0].content[2].irefs, list)
+        if not isinstance( middle.content[0].content[2].irefs, list): # type-check
+            return
+        self.assertEqual( len(middle.content[0].content[2].irefs), 0)
+        # sec-00  content[2] <Figure>  preamble
+        self.assertIsNone( middle.content[0].content[2].preamble)
+        # sec-00  content[2] <Figure>  artwork
+        self.assertIsInstance( middle.content[0].content[2].content, list)
+        self.assertEqual( len(middle.content[0].content[2].content), 1)
+        self.assertIsInstance( middle.content[0].content[2].content[0], rfc.Artwork)
+        if not isinstance( middle.content[0].content[2].content[0], rfc.Artwork): # type-check
+            return
+        self.assertIsInstance( middle.content[0].content[2].content[0].content , rfc.Text)
+        if not isinstance( middle.content[0].content[2].content[0].content , rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[0].content[2].content[0].content.content , """
+:    0                   1                   2                   3
+:    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |          Source Port          |       Destination Port        |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                        Sequence Number                        |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                    Acknowledgment Number                      |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |  Data |           |U|A|P|R|S|F|                               |
+:   | Offset| Reserved  |R|C|S|S|Y|I|            Window             |
+:   |       |           |G|K|H|T|N|N|                               |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |           Checksum            |         Urgent Pointer        |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                    Options                    |    Padding    |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                             data                              |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            """)
+        self.assertEqual( middle.content[0].content[2].content[0].align, "left")
+        self.assertIsNone( middle.content[0].content[2].content[0].alt)
+        self.assertIsNone( middle.content[0].content[2].content[0].anchor)
+        self.assertIsNone( middle.content[0].content[2].content[0].height)
+        self.assertIsNone( middle.content[0].content[2].content[0].name)
+        self.assertIsNone( middle.content[0].content[2].content[0].src)
+        self.assertIsNone( middle.content[0].content[2].content[0].type)
+        self.assertIsNone( middle.content[0].content[2].content[0].width)
+        self.assertIsNone( middle.content[0].content[2].content[0].xmlSpace)
+        # sec-00  content[2] <Figure>  postamble
+        self.assertIsNone( middle.content[0].content[2].postamble)
+        # sec-00  content[2] <Figure>  align, alt, anchor, height, src, suppress
+        self.assertEqual( middle.content[0].content[2].align, "left")
+        self.assertIsNone( middle.content[0].content[2].alt)
+        self.assertIsNotNone( middle.content[0].content[2].anchor)
+        self.assertEqual( middle.content[0].content[2].anchor, "tcp-header-format")
+        self.assertIsNone( middle.content[0].content[2].height)
+        self.assertIsNone( middle.content[0].content[2].src)
+        self.assertIsInstance( middle.content[0].content[2].suppressTitle, bool)
+        self.assertFalse( middle.content[0].content[2].suppressTitle, False)
+        self.assertIsNone( middle.content[0].content[2].title)
+        self.assertIsNone( middle.content[0].content[2].width)
+
+
+        # sec-00  content[3] <T> 
+        self.assertIsInstance(middle.content[0].content[3], rfc.T)
+        if not isinstance(middle.content[0].content[3], rfc.T): #type-check
+            return
+        # sec-00  content[3] <T>  Text
+        self.assertIsInstance( middle.content[0].content[3].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[3].content), 2)
+        self.assertIsInstance( middle.content[0].content[3].content[0], rfc.Text)
+        if not isinstance( middle.content[0].content[3].content[0], rfc.Text): # type-check 
+            return
+
+        self.assertEqual( middle.content[0].content[3].content[0].content, """
+                Unfortunately, the format of such packet diagrams varies both within
+                and between documents. This variation makes it difficult to build
+                tools to generate parsers from the specifications. Better tooling
+                could be developed if protocol specifications adopted a consistent
+                format for their packet descriptions. Indeed,
+                this underpins the format described by this draft: we want to
+                retain the benefits that packet header diagrams provide, while identifying
+                the benefits of adopting a consistent format.
+             """)
+        self.assertIsInstance( middle.content[0].content[3].content[1], rfc.Text) 
+        if not isinstance( middle.content[0].content[3].content[1], rfc.Text) : # type-check
+            return
+        #FIXME - unnecessary empty tag 
+        self.assertEqual( middle.content[0].content[3].content[1].content, """
+            """)
+        # sec-00  content[3] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[3].anchor)
+        self.assertIsNone( middle.content[0].content[3].hangText)
+        self.assertFalse( middle.content[0].content[3].keepWithNext)
+        self.assertFalse( middle.content[0].content[3].keepWithPrevious)
+
+        # sec-00  content[4] <T> 
+        self.assertIsInstance(middle.content[0].content[4], rfc.T)
+        if not isinstance(middle.content[0].content[4], rfc.T): #type-check
+            return
+        # sec-00  content[4] <T>  Text
+        self.assertIsInstance( middle.content[0].content[4].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[4].content), 2)
+        self.assertIsInstance( middle.content[0].content[4].content[0], rfc.Text)
+        if not isinstance( middle.content[0].content[4].content[0], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[0].content[4].content[0].content, """
+                This document describes a consistent packet header diagram format and
+                accompanying structured text constructs that allow for the parsing process
+                of protocol headers to be fully specified. This provides support for the
+                automatic generation of parser code. Broad design principles, that seek
+                to maintain the primacy of human readability and flexibility in
+                writing, are described, before the format itself is given.
+            """)
+
+        self.assertIsInstance( middle.content[0].content[4].content[1], rfc.Text) 
+        if not isinstance( middle.content[0].content[4].content[1], rfc.Text) : # type-check
+            return
+        #FIXME - unnecessary empty tag 
+        self.assertEqual( middle.content[0].content[4].content[1].content, """
+            """)
+        # sec-00  content[4] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[4].anchor)
+        self.assertIsNone( middle.content[0].content[4].hangText)
+        self.assertFalse( middle.content[0].content[4].keepWithNext)
+        self.assertFalse( middle.content[0].content[4].keepWithPrevious)
+
+
+        # sec-00  content[5] <T> 
+        self.assertIsInstance(middle.content[0].content[5], rfc.T)
+        if not isinstance(middle.content[0].content[5], rfc.T): # type-check
+            return
+        # sec-00  content[5] <T>  Text
+        self.assertIsInstance( middle.content[0].content[5].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[5].content), 2)
+        self.assertIsInstance( middle.content[0].content[5].content[0], rfc.Text)
+        if not isinstance( middle.content[0].content[5].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[0].content[5].content[0].content, """
+                This document is itself an example of the approach that it describes, with
+                the packet header diagrams and structured text format described by example.
+                Examples that do not form part of the protocol description language are
+                marked by a colon at the beginning of each line; this prevents them from
+                being parsed by the accompanying tooling.
+            """)
+        #FIXME - unnecessary empty tag 
+        self.assertIsInstance( middle.content[0].content[5].content[1], rfc.Text) 
+        if not isinstance( middle.content[0].content[5].content[1], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[0].content[5].content[1].content, """
+            """)
+        # sec-00  content[5] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[5].anchor)
+        self.assertIsNone( middle.content[0].content[5].hangText)
+        self.assertFalse( middle.content[0].content[5].keepWithNext)
+        self.assertFalse( middle.content[0].content[5].keepWithPrevious)
+
+
+        # sec-00  content[6] <T> 
+        self.assertIsInstance(middle.content[0].content[6], rfc.T)
+        if not isinstance(middle.content[0].content[6], rfc.T): # type-check
+            return
+        # sec-00  content[6] <T>  Text
+        self.assertIsInstance( middle.content[0].content[6].content, list)
+        # FIXME : unnecessary single newline - strip empty tail
+        self.assertEqual( len(middle.content[0].content[6].content), 6)
+        self.assertIsInstance( middle.content[0].content[6].content[0], rfc.Text)
+        if not isinstance( middle.content[0].content[6].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[0].content[6].content[0].content, """
+                This draft describes early work. As consensus builds around the
+                particular syntax of the format described, both a formal ABNF
+                specification (""")
+        self.assertIsInstance( middle.content[0].content[6].content[1], rfc.XRef)
+        if not isinstance( middle.content[0].content[6].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[0].content[6].content[1].content)
+        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
+        self.assertIsNone( middle.content[0].content[6].content[1].format)
+        self.assertFalse( middle.content[0].content[6].content[1].pageno)
+        self.assertEqual( middle.content[0].content[6].content[1].target, "ABNF")
+        self.assertIsInstance( middle.content[0].content[6].content[2], rfc.Text)
+        if not isinstance( middle.content[0].content[6].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[0].content[6].content[2].content, ") and code (")
+        self.assertIsInstance( middle.content[0].content[6].content[3], rfc.XRef)
+        if not isinstance( middle.content[0].content[6].content[3], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[0].content[6].content[3].content)
+        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
+        self.assertIsNone( middle.content[0].content[6].content[3].format)
+        self.assertFalse( middle.content[0].content[6].content[3].pageno)
+        self.assertEqual( middle.content[0].content[6].content[3].target, "source")
+        self.assertIsInstance( middle.content[0].content[6].content[4], rfc.Text)
+        if not isinstance( middle.content[0].content[6].content[4], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[0].content[6].content[4].content, """) that
+                parses it (and, as described above, this document) will be provided.
+            """)
+        #FIXME - unnecessary empty tag 
+        self.assertIsInstance( middle.content[0].content[6].content[5], rfc.Text) 
+        if not isinstance( middle.content[0].content[6].content[5], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[0].content[6].content[5].content, """
+        """)
+
+        # sec-00  content[6] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[0].content[6].anchor)
+        self.assertIsNone( middle.content[0].content[6].hangText)
+        self.assertFalse( middle.content[0].content[6].keepWithNext)
+        self.assertFalse( middle.content[0].content[6].keepWithPrevious)
+
+
+
+        # sec-00  sections 
+        self.assertIsInstance(middle.content[0].sections, list)
+        if not isinstance(middle.content[0].sections, list): # type-check
+            return
+        self.assertEqual(len(middle.content[0].sections), 0)
+        # sec-00  anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[0].anchor, "intro")
+        self.assertTrue(middle.content[0].numbered)
+        self.assertFalse(middle.content[0].removeInRFC)
+        self.assertIsNone(middle.content[0].title)
+        self.assertEqual(middle.content[0].toc, "default" )
+
+
+
+        # sec-01
+        self.assertIsInstance(middle.content[1], rfc.Section)
+        # sec-01  name 
+        self.assertIsNotNone( middle.content[1].name) 
+        self.assertIsInstance( middle.content[1].name, rfc.Name) 
+        if not isinstance( middle.content[1].name, rfc.Name) : # type-check
+            return
+        self.assertEqual( len(middle.content[1].name.content), 1) 
+        self.assertIsInstance( middle.content[1].name.content[0], rfc.Text) 
+        self.assertEqual( middle.content[1].name.content[0].content, "Background") 
+        # sec-01  content
+        self.assertIsInstance( middle.content[1].content, list) 
+        self.assertEqual( len(middle.content[1].content), 2) 
+        # sec-01  content[0] <T>
+        self.assertIsInstance( middle.content[1].content[0], rfc.T) 
+        if not isinstance( middle.content[1].content[0], rfc.T) : # type-check
+            return
+        self.assertIsInstance( middle.content[1].content[0].content, list) 
+        self.assertEqual( len(middle.content[1].content[0].content), 2) 
+        self.assertIsInstance( middle.content[1].content[0].content[0], rfc.Text) 
+        if not isinstance( middle.content[1].content[0].content[0], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[1].content[0].content[0].content, """
+                This section begins by considering how packet header diagrams are
+                used in existing documents. This exposes the limitations that the current
+                usage has in terms of machine-readability, guiding the design of the
+                format that this document proposes.
+            """)
+        #FIXME :  unused newline within tag
+        self.assertIsInstance( middle.content[1].content[0].content[1], rfc.Text) 
+        if not isinstance( middle.content[1].content[0].content[1], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[1].content[0].content[1].content, """
+            """)
+        # sec-01  content[0] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].content[0].anchor)
+        self.assertIsNone( middle.content[1].content[0].hangText)
+        self.assertFalse( middle.content[1].content[0].keepWithNext)
+        self.assertFalse( middle.content[1].content[0].keepWithPrevious)
+
+        # sec-01  content[1] <T>
+        self.assertIsInstance( middle.content[1].content[1], rfc.T) 
+        if not isinstance( middle.content[1].content[1], rfc.T) : # type-check
+            return
+        self.assertIsInstance( middle.content[1].content[1].content, list) 
+        self.assertEqual( len(middle.content[1].content[1].content), 2) 
+        self.assertIsInstance( middle.content[1].content[1].content[0], rfc.Text) 
+        if not isinstance( middle.content[1].content[1].content[0], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[1].content[1].content[0].content, """
+                While this document focuses on the machine-readability of packet format
+                diagrams, this section also discusses the use of other structured or formal
+                languages within IETF documents. Considering how and why these languages
+                are used provides an instructive contrast to the relatively incremental
+                approach proposed here.
+            """)
+        #FIXME :  unused newline within tag
+        self.assertIsInstance( middle.content[1].content[1].content[1], rfc.Text) 
+        if not isinstance( middle.content[1].content[1].content[1], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[1].content[1].content[1].content, """
+
+            """)
+        # sec-01  content[1] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].content[1].anchor)
+        self.assertIsNone( middle.content[1].content[1].hangText)
+        self.assertFalse( middle.content[1].content[1].keepWithNext)
+        self.assertFalse( middle.content[1].content[1].keepWithPrevious)
+
+        # sec-01  sections
+        self.assertIsInstance( middle.content[1].sections, list) 
+        if not isinstance( middle.content[1].sections, list) : # type-check
+            return
+        self.assertEqual( len(middle.content[1].sections), 2) 
+        # sec-01  sub-sec[0] 
+        self.assertIsInstance( middle.content[1].sections[0], rfc.Section) 
+        # sec-01  sub-sec[0] name
+        self.assertIsNotNone( middle.content[1].sections[0].name)
+        self.assertIsInstance( middle.content[1].sections[0].name, rfc.Name) 
+        if not isinstance( middle.content[1].sections[0].name, rfc.Name) : # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].name.content, list) 
+        self.assertEqual( len(middle.content[1].sections[0].name.content), 1) 
+        self.assertIsInstance( middle.content[1].sections[0].name.content[0],  rfc.Text) 
+        self.assertEqual( middle.content[1].sections[0].name.content[0].content, "Limitations of Current Packet Format Diagrams" ) 
+        # sec-01  sub-sec[0] content
+        self.assertIsInstance( middle.content[1].sections[0].content, list)
+        self.assertEqual( len( middle.content[1].sections[0].content), 5)
+        # sec-01  sub-sec[0] content[0] <Figure>
+        self.assertIsInstance( middle.content[1].sections[0].content[0], rfc.Figure)
+        if not isinstance( middle.content[1].sections[0].content[0], rfc.Figure): # type-check
+            return
+        # sec-01  sub-sec[0] content[0] <Figure> name 
+        self.assertIsNotNone( middle.content[1].sections[0].content[0].name)
+        self.assertIsInstance( middle.content[1].sections[0].content[0].name, rfc.Name)
+        if not isinstance( middle.content[1].sections[0].content[0].name, rfc.Name): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[0].name.content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[0].name.content), 2)
+        self.assertIsInstance( middle.content[1].sections[0].content[0].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[1].sections[0].content[0].name.content[0].content, "QUIC's RESET_STREAM frame format (from ")
+        self.assertIsInstance( middle.content[1].sections[0].content[0].name.content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[0].name.content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[0].name.content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[0].name.content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[0].name.content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[0].name.content[1].target, "QUIC-TRANSPORT")
+        # sec-01  sub-sec[0] content[0] <Figure> irefs
+        self.assertIsInstance( middle.content[1].sections[0].content[0].irefs, list)
+        if not isinstance( middle.content[1].sections[0].content[0].irefs, list): # type-check
+            return
+        self.assertEqual( len(middle.content[1].sections[0].content[0].irefs), 0)
+        # sec-01  sub-sec[0] content[0] <Figure> preamble
+        self.assertIsNone( middle.content[1].sections[0].content[0].preamble)
+        # sec-01  sub-sec[0] content[0] <Figure> content
+        self.assertIsInstance( middle.content[1].sections[0].content[0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[0].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[0].content[0], rfc.Artwork)
+        if not isinstance( middle.content[1].sections[0].content[0].content[0], rfc.Artwork): # type-check
+            return
+        # sec-01  sub-sec[0] content[0] <Figure> content[0] <artwork> content
+        self.assertIsInstance( middle.content[1].sections[0].content[0].content[0].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[0].content[0].content, rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[0].content[0].content.content, """
+:   The RESET_STREAM frame is as follows:
+:
+:    0                   1                   2                   3
+:    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                        Stream ID (i)                        ...
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |  Application Error Code (16)  |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |                        Final Size (i)                       ...
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:
+:   RESET_STREAM frames contain the following fields:
+:
+:   Stream ID:  A variable-length integer encoding of the Stream ID
+:      of the stream being terminated.
+:
+:   Application Protocol Error Code:  A 16-bit application protocol
+:      error code (see Section 20.1) which indicates why the stream
+:      is being closed.
+:
+:   Final Size: A variable-length integer indicating the final size
+:      of the stream by the RESET_STREAM sender, in unit of bytes.
+                  """)
+        # sec-01  sub-sec[0] content[0] <Figure> content[0] <artwork> align, alt, anchor, height, name, src, type, width, xmlSpace
+        self.assertEqual( middle.content[1].sections[0].content[0].content[0].align, "left")
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].alt)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].height)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].name)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].src)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].type)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].width)
+        self.assertIsNone( middle.content[1].sections[0].content[0].content[0].xmlSpace)
+        # sec-01  sub-sec[0] content[0] <Figure> postamble
+        self.assertIsNone( middle.content[1].sections[0].content[0].postamble)
+        # sec-01  sub-sec[0] content[0] <Figure> align, alt, anchor, height, src, suppressTitle, title, width
+        self.assertEqual( middle.content[1].sections[0].content[0].align, "left")
+        self.assertIsNone( middle.content[1].sections[0].content[0].alt)
+        self.assertIsNotNone( middle.content[1].sections[0].content[0].anchor)
+        self.assertEqual( middle.content[1].sections[0].content[0].anchor, "quic-reset-stream")
+        self.assertIsNone( middle.content[1].sections[0].content[0].height)
+        self.assertIsNone( middle.content[1].sections[0].content[0].src )
+        self.assertIsInstance( middle.content[1].sections[0].content[0].suppressTitle, bool)
+        self.assertFalse( middle.content[1].sections[0].content[0].suppressTitle, False)
+        self.assertIsNone( middle.content[1].sections[0].content[0].title)
+        self.assertIsNone( middle.content[1].sections[0].content[0].width)
+
+        # sec-01  sub-sec[0] content[1] <T>
+        self.assertIsInstance( middle.content[1].sections[0].content[1], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[1], rfc.T): # type-check
+            return
+        # sec-01  sub-sec[0] content[1] <T> content
+        self.assertIsInstance( middle.content[1].sections[0].content[1].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[1].content), 4)
+        self.assertIsInstance( middle.content[1].sections[0].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[1].content[0].content, """
+                  Packet header diagrams are frequently used in IETF standards to describe the
+                  format of binary protocols. While there is no standard for how
+                  these diagrams should be formatted, they have a broadly similar structure,
+                  where the layout of a protocol data unit (PDU) or structure is shown in
+                  diagrammatic form, followed by a description list of the fields that it
+                  contains. An example of this format, taken from the QUIC specification,
+                  is given in """)
+        self.assertIsInstance( middle.content[1].sections[0].content[1].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[1].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[1].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[1].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[1].content[1].target, "quic-reset-stream")
+        self.assertIsInstance( middle.content[1].sections[0].content[1].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[1].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[1].content[2].content, """.
+                """)
+        self.assertIsInstance( middle.content[1].sections[0].content[1].content[3], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[1].content[3], rfc.Text): # type-check
+            return
+        #FIXME : unnecessary newline 
+        self.assertEqual( middle.content[1].sections[0].content[1].content[3].content, """
+
+                """)
+        # sec-01  sub-sec[0] content[2] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].sections[0].content[1].anchor) 
+        self.assertIsNone( middle.content[1].sections[0].content[1].hangText) 
+        self.assertFalse( middle.content[1].sections[0].content[1].keepWithNext) 
+        self.assertFalse( middle.content[1].sections[0].content[1].keepWithPrevious) 
+
+
+        # sec-01  sub-sec[0] content[2] <T>
+        self.assertIsInstance( middle.content[1].sections[0].content[2], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[2], rfc.T): # type-check
+            return
+        # sec-01  sub-sec[0] content[2] <T> content <Text>
+        self.assertIsInstance( middle.content[1].sections[0].content[2].content, list)
+        #FIXME : extra newline 
+        self.assertEqual( len(middle.content[1].sections[0].content[2].content), 2)
+        self.assertIsInstance( middle.content[1].sections[0].content[2].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[2].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[2].content[0].content, """
+                  These packet header diagrams, and the accompanying descriptions, are
+                  formatted for human readers rather than for automated processing. As
+                  a result, while there is rough consistency in how packet header diagrams are
+                  formatted, there are a number of limitations that make them difficult
+                  to work with programmatically:
+                """)
+        self.assertIsInstance( middle.content[1].sections[0].content[2].content[1], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[2].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[2].content[1].content, """
+                """)
+        # sec-01  sub-sec[0] content[2] <T>  anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].sections[0].content[2].anchor) 
+        self.assertIsNone( middle.content[1].sections[0].content[2].hangText) 
+        self.assertFalse( middle.content[1].sections[0].content[2].keepWithNext) 
+        self.assertFalse( middle.content[1].sections[0].content[2].keepWithPrevious) 
+
+        # sec-01  sub-sec[0] content[3] <DL>
+        self.assertIsInstance( middle.content[1].sections[0].content[3], rfc.DL) 
+        if not isinstance( middle.content[1].sections[0].content[3], rfc.DL) : # type-check
+            return
+        # sec-01  sub-sec[0] content[3] <DL> content
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content, list) 
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content), 4) 
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0], tuple)
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [0] <DT> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][0].content[0].content, """
+                    Inconsistent syntax:
+                  """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][0].anchor)
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content, list)
+        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content), 3)
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[0] <T> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[0].content[0].content, """
+                      There are two classes of consistency that are needed to support
+                      automated processing of specifications: internal consistency
+                      within a diagram or document, and external consistency across
+                      all documents.
+                    """)
+        # FIXME : extra line item in tag <T> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1].content, """
+                      """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[0].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[0].keepWithPrevious)
+
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[1] <T> 
+        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[1].content), 8)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[0].content, """
+                        """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].target, "quic-reset-stream")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[2].content, 
+                        """ gives an example of internal
+                        inconsistency. Here, the packet diagram shows a field labelled
+                        "Application Error Code", while the accompanying description lists
+                        the field as "Application Protocol Error Code". The use of an
+                        abbreviated name is suitable for human readers, but makes parsing
+                        the structure difficult for machines.
+
+                        """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].target, "dhcpv6-relaysrcopt")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[4], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[4], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[4].content, 
+                        """ gives a further example, where
+                        the description includes an "Option-Code" field that does not appear
+                        in the packet diagram; and where the description states that
+                        each field is 16 bits in length, but the diagram shows
+                        the OPTION_RELAY_PORT as 13 bits, and Option-Len as 19 bits.
+
+                        Another example is """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].target, "RFC6958")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[6], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[6], rfc.Text): #type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[6].content, 
+                      """, where the packet
+                        format diagram showing the structure of the Burst/Gap Loss Metrics
+                        Report Block shows the Number of Bursts field as being 12 bits wide
+                        but the corresponding text describes it as 16 bits.
+                      """)
+        # FIXME : extra line item in tag <T> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7].content, """
+
+                      """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].keepWithPrevious)
+
+        # sec-01  sub-sec[0] content[3] <DL> content[0] <tuple<DT,DD>>  [1] <DD> content[2] <T> 
+        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content, list)
+        #FIXME :  class <T> additional line due to newline
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[2].content), 6)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0].content, """
+                        Comparing """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].target, "quic-reset-stream")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[2].content, """ with
+                        """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].target, "dhcpv6-relaysrcopt")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[4], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[4], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[4].content, """ exposes external
+                        inconsistency across documents. While the packet format
+                        diagrams are broadly similar, the surrounding text is
+                        formatted differently. If machine parsing is to be made
+                        possible, then this text must be structured consistently.
+                      """)
+        #FIXME :  class <T> additional line due to newline
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5], rfc.Text): #type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5].content, """
+                    """)
+
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].keepWithPrevious)
+
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].anchor)
+
+
+
+        # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1], tuple)
+        # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>  [0] <DT> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][0], rfc.DT)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[1][0].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[1][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[1][0].content[0].content, """
+                      Ambiguous constraints:
+                    """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[1][0].anchor)
+        # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>  [1] <DD> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1], rfc.DD)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content, list)
+        # FIXME !!! <Tuple<DT,DD>>  not being parsed for <T> 
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[1][1].content), 3)
+        # sec-01  sub-sec[0] content[3] <DL> content[1] <tuple<DT,DD>>  [1] <DD> content[0] <Text> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[1][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[1][1].content[0].content, """
+                      The constraints that are enforced on a particular field are often
+                      described ambiguously, or in a way that cannot be parsed easily.
+                      In """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[1][1].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[1][1].content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[1][1].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[1][1].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[1][1].content[1].target, "dhcpv6-relaysrcopt")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[1][1].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[1][1].content[2].content,
+                    """, each of the three fields
+                      in the structure is constrained. The first two fields
+                      ("Option-Code" and "Option-Len") are to be set to constant values
+                      (note the inconsistency in how these constraints are expressed in
+                      the description). However, the third field ("Downstream Source
+                      Port") can take a value from a constrained set. This constraint
+                      is expressed in prose that cannot readily by understood by machine.
+                    """)
+
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[1][1].anchor)
+                    
+
+        # sec-01  sub-sec[0] content[3] <DL> content[2] <tuple<DT,DD>>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2], tuple)
+        # sec-01  sub-sec[0] content[3] <DL> content[2] <tuple<DT,DD>>  [0] <DT> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][0], rfc.DT)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][0].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][0].content[0].content, """
+                      Poor linking between sub-structures:
+                    """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][0].anchor)
+        # sec-01  sub-sec[0] content[3] <DL> content[2] <tuple<DT,DD>>  [1] <DD> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1], rfc.DD)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content), 2)
+        # sec-01  sub-sec[0] content[3] <DL> content[2] <tuple<DT,DD>>  [1] <DD> [0] <T>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content, list)
+        #FIXME : <T>  remove empty tail
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[0].content[0].content, """
+                        Protocol data units and other structures are often comprised of
+                        sub-structures that are defined elsewhere, either in the same
+                        document, or within another document. Chaining these structures
+                        together is essential for machine parsing: the parsing process for
+                        a protocol data unit is only fully expressed if all elements can
+                        be parsed.
+                      """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1].content, """
+                      """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[0].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[0].keepWithPrevious)
+        # sec-01  sub-sec[0] content[3] <DL> content[2] <tuple<DT,DD>>  [1] <DD> [1] <T>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1], rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content, list)
+        #FIXME : <T>  remove empty tail
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[1].content), 4)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[0], rfc.Text): # type-check 
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[0].content, """
+                        """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].target, "quic-reset-stream")
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[2].content, 
+                      """ highlights the difficulty that
+                        machine parsers have in chaining structures together. Two fields
+                        ("Stream ID" and "Final Size") are described as being encoded as
+                        variable-length integers; this is a structure described elsewhere
+                        in the same document. Structured text is required both alongside
+                        the definition of the containing structure and with the definition
+                        of the sub-structure, to allow a parser to link the two together.
+                      """)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3].content, """
+                    """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[1].keepWithPrevious)
+
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].anchor)
+
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3], tuple)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DT> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][0], rfc.DT)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][0].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[3][0].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][0].content[0], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][0].content[0].content, """
+                        Lack of extension and evolution syntax:
+                    """)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][0].anchor)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> 
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1], rfc.DD)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[3][1].content), 1)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0],  rfc.T)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0],  rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content, list)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[3][1].content[0].content), 4)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[0] <Text>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[0].content, """
+                            Protocols are often specified across multiple documents, either
+                            because the protocol explicitly includes extension points (e.g.,
+                            profiles and payload format specifications in RTP
+                            """)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[1] <XRef>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].target, "RFC3550")
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[2] <Text>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[2].content, 
+                        """) or because definition of a protocol
+                            data unit has changed and evolved over time. As a result, it is
+                            essential that syntax be provided to allow for a complete
+                            definition of a protocol's parsing process to be constructed
+                            across multiple documents.
+                        """)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[3] <Text>
+        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3], rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3].content, """
+                    """)
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> 
+        # anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].hangText)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[3][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[1].sections[0].content[3].content[3][1].content[0].keepWithPrevious)
+
+        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> anchor
+        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].anchor)
+
+        # sec-01  sub-sec[0] content[3] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[1].sections[0].content[3].anchor)
+        self.assertTrue( middle.content[1].sections[0].content[3].hanging)
+        self.assertEqual( middle.content[1].sections[0].content[3].spacing, "normal")
+
+
+        # sec-01  sub-sec[0] content[4] <Figure>
+        self.assertIsInstance( middle.content[1].sections[0].content[4], rfc.Figure)
+        if not isinstance( middle.content[1].sections[0].content[4], rfc.Figure): # type-check
+            return
+        # sec-01  sub-sec[0] content[4] <Figure> name 
+        self.assertIsNotNone( middle.content[1].sections[0].content[4].name)
+        self.assertIsInstance( middle.content[1].sections[0].content[4].name, rfc.Name)
+        if not isinstance( middle.content[1].sections[0].content[4].name, rfc.Name): # type-check
+            return
+        self.assertIsInstance( middle.content[1].sections[0].content[4].name.content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[4].name.content), 2)
+        self.assertIsInstance( middle.content[1].sections[0].content[4].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[1].sections[0].content[4].name.content[0].content, "DHCPv6's Relay Source Port Option (from ")
+        self.assertIsInstance( middle.content[1].sections[0].content[4].name.content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[0].content[4].name.content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[0].content[4].name.content[1].content)
+        self.assertIsNone( middle.content[1].sections[0].content[4].name.content[1].format)
+        self.assertFalse( middle.content[1].sections[0].content[4].name.content[1].pageno)
+        self.assertEqual( middle.content[1].sections[0].content[4].name.content[1].target, "RFC8357")
+        # sec-01  sub-sec[0] content[4] <Figure> irefs
+        self.assertIsInstance( middle.content[1].sections[0].content[4].irefs, list)
+        if not isinstance( middle.content[1].sections[0].content[4].irefs, list): # type-check
+            return
+        self.assertEqual( len(middle.content[1].sections[0].content[4].irefs), 0)
+        # sec-01  sub-sec[0] content[4] <Figure> preamble
+        self.assertIsNone( middle.content[1].sections[0].content[4].preamble)
+        # sec-01  sub-sec[0] content[4] <Figure> content
+        self.assertIsInstance( middle.content[1].sections[0].content[4].content, list)
+        self.assertEqual( len(middle.content[1].sections[0].content[4].content), 1)
+        self.assertIsInstance( middle.content[1].sections[0].content[4].content[0], rfc.Artwork)
+        if not isinstance( middle.content[1].sections[0].content[4].content[0], rfc.Artwork): # type-check
+            return
+        # sec-01  sub-sec[0] content[4] <Figure> content[0] <artwork> content
+        self.assertIsInstance( middle.content[1].sections[0].content[4].content[0].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[4].content[0].content, rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[0].content[4].content[0].content.content, """
+:   The format of the "Relay Source Port Option" is shown below:
+:
+:    0                   1                   2                   3
+:    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |    OPTION_RELAY_PORT    |         Option-Len                  |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:   |    Downstream Source Port     |
+:   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+:
+:   Where:
+:
+:   Option-Code:  OPTION_RELAY_PORT. 16-bit value, 135.
+:
+:   Option-Len:  16-bit value to be set to 2.
+:
+:   Downstream Source Port:  16-bit value.  To be set by the IPv6
+:      relay either to the downstream relay agent's UDP source port
+:      used for the UDP packet, or to zero if only the local relay
+:      agent uses the non-DHCP UDP port (not 547).
+                  """)
+        # sec-01  sub-sec[0] content[4] <Figure> content[4] <artwork> align, alt, anchor, height, name, src, type, width, xmlSpace
+        self.assertEqual( middle.content[1].sections[0].content[4].content[0].align, "left")
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].alt)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].height)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].name)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].src)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].type)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].width)
+        self.assertIsNone( middle.content[1].sections[0].content[4].content[0].xmlSpace)
+        # sec-01  sub-sec[0] content[4] <Figure> postamble
+        self.assertIsNone( middle.content[1].sections[0].content[4].postamble)
+        # sec-01  sub-sec[0] content[4] <Figure> align, alt, anchor, height, src, suppressTitle, title, width
+        self.assertEqual( middle.content[1].sections[0].content[4].align, "left")
+        self.assertIsNone( middle.content[1].sections[0].content[4].alt)
+        self.assertIsNotNone( middle.content[1].sections[0].content[4].anchor)
+        self.assertEqual( middle.content[1].sections[0].content[4].anchor, "dhcpv6-relaysrcopt")
+        self.assertIsNone( middle.content[1].sections[0].content[4].height)
+        self.assertIsNone( middle.content[1].sections[0].content[4].src )
+        self.assertIsInstance( middle.content[1].sections[0].content[4].suppressTitle, bool)
+        self.assertFalse( middle.content[1].sections[0].content[4].suppressTitle, False)
+        self.assertIsNone( middle.content[1].sections[0].content[4].title)
+        self.assertIsNone( middle.content[1].sections[0].content[4].width)
+
+        # sec-01  sub-sec[0] sections
+        self.assertIsInstance( middle.content[1].sections[0].sections, list)
+        if not isinstance( middle.content[1].sections[0].sections, list): # type-check 
+            return
+        self.assertEqual( len( middle.content[1].sections[0].sections), 0)
+        # sec-01  sub-sec[0] anchor, numbered, removeInRFC, title, toc
+        self.assertEqual(middle.content[1].sections[0].anchor, "background-ascii")
+        self.assertTrue(middle.content[1].sections[0].numbered)
+        self.assertFalse(middle.content[1].sections[0].removeInRFC)
+        self.assertIsNone(middle.content[1].sections[0].title)
+        self.assertEqual(middle.content[1].sections[0].toc, "default" )
+
+        # sec-01  sub-sec[1] 
+        self.assertIsInstance(middle.content[1].sections[1], rfc.Section)
+        # sec-01  sub-sec[1] name 
+        self.assertIsInstance(middle.content[1].sections[1].name, rfc.Name)
+        if not isinstance(middle.content[1].sections[1].name, rfc.Name): # type-check
+            return
+        self.assertIsInstance(middle.content[1].sections[1].name.content, list)
+        self.assertEqual( len(middle.content[1].sections[1].name.content), 1)
+        self.assertIsInstance( middle.content[1].sections[1].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[1].sections[1].name.content[0].content, "Formal languages in standards documents")
+        # sec-01  sub-sec[1] content 
+        self.assertIsInstance( middle.content[1].sections[1].content, list)
+        self.assertEqual( len(middle.content[1].sections[1].content), 1)
+        # FIXME : Additional element from <T> tail
+        self.assertIsInstance( middle.content[1].sections[1].content[0], rfc.T)
+        if not isinstance( middle.content[1].sections[1].content[0], rfc.T): # type-check
+            return
+        # FIXME : Additional element from <T> tail content
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content, list)
+        self.assertEqual( len(middle.content[1].sections[1].content[0].content), 12)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[0], rfc.Text): # type-check 
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[0].content, """
+                    A small proportion of IETF standards documents contain
+                    structured and formal languages, including ABNF """)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[1], rfc.XRef)
+        if not isinstance( middle.content[1].sections[1].content[0].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[1].content)
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[1].format)
+        self.assertFalse( middle.content[1].sections[1].content[0].content[1].pageno)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[1].target, "RFC5234")
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[2], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[2].content, """,
+                    ASN.1 """)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[3], rfc.XRef)
+        if not isinstance( middle.content[1].sections[1].content[0].content[3], rfc.XRef):  # type-check
+             return
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[3].content)
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[3].format)
+        self.assertFalse( middle.content[1].sections[1].content[0].content[3].pageno)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[3].target, "ASN1")
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[4], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[4], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[4].content, """, C, CBOR """)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[5], rfc.XRef)
+        if not isinstance( middle.content[1].sections[1].content[0].content[5], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[5].content)
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[5].format)
+        self.assertFalse( middle.content[1].sections[1].content[0].content[5].pageno)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[5].target, "RFC7049")
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[6], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[6], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[6].content, """, JSON,
+                    the TLS presentation language """)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[7], rfc.XRef)
+        if not isinstance( middle.content[1].sections[1].content[0].content[7], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[7].content)
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[7].format)
+        self.assertFalse( middle.content[1].sections[1].content[0].content[7].pageno)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[7].target, "RFC8446")
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[8], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[8], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[8].content, """, YANG models
+                    """)
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[9], rfc.XRef)
+        if not isinstance( middle.content[1].sections[1].content[0].content[9], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[9].content)
+        self.assertIsNone( middle.content[1].sections[1].content[0].content[9].format)
+        self.assertFalse( middle.content[1].sections[1].content[0].content[9].pageno)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[9].target, "RFC7950")
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[10], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[10], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[10].content, """, and XML. While this broad
+                    range of languages may be problematic for the development of tooling
+                    to parse specifications, these, and other, languages serve a range of
+                    different use cases. ABNF, for example, is typically used to specify
+                    text protocols, while ASN.1 is used to specify data structure
+                    serialisation. This document specifies a structured language for specifying
+                    the parsing of binary protocol data units.
+                """)
+        # FIXME : Additional element from <T> tail content[11] <Text>
+        self.assertIsInstance( middle.content[1].sections[1].content[0].content[11], rfc.Text)
+        if not isinstance( middle.content[1].sections[1].content[0].content[11], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[1].sections[1].content[0].content[11].content, """
+            """)
+        # sec-01  sub-sec[1] content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[1].sections[1].content[0].anchor)
+        self.assertIsNone( middle.content[1].sections[1].content[0].hangText)
+        self.assertFalse( middle.content[1].sections[1].content[0].keepWithNext)
+        self.assertFalse( middle.content[1].sections[1].content[0].keepWithPrevious)
+
+        # sec-01  sub-sec[1] sections 
+        self.assertIsInstance( middle.content[1].sections[1].sections, list)
+        if not isinstance( middle.content[1].sections[1].sections, list): # type-check
+            return
+        self.assertEqual( len(middle.content[1].sections[1].sections), 0)
+
+        # sec-01  sub-sec[1] anchor, numbered, removeInRFC, title, toc
+        self.assertEqual(middle.content[1].sections[1].anchor, "background-others")
+        self.assertTrue(middle.content[1].sections[1].numbered)
+        self.assertFalse(middle.content[1].sections[1].removeInRFC)
+        self.assertIsNone(middle.content[1].sections[1].title)
+        self.assertEqual(middle.content[1].sections[1].toc, "default" )
+
+        # sec-01  anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[1].anchor, "background")
+        self.assertTrue(middle.content[1].numbered)
+        self.assertFalse(middle.content[1].removeInRFC)
+        self.assertIsNone(middle.content[1].title)
+        self.assertEqual(middle.content[1].toc, "default" )
+
+        # sec-02
+        self.assertIsInstance(middle.content[2], rfc.Section)
+        # sec-02 name
+        self.assertIsNotNone( middle.content[2].name) 
+        self.assertIsInstance( middle.content[2].name, rfc.Name) 
+        if not isinstance( middle.content[2].name, rfc.Name) : # type-check
+            return
+        self.assertEqual( len(middle.content[2].name.content), 1) 
+        self.assertIsInstance( middle.content[2].name.content[0], rfc.Text) 
+        self.assertEqual( middle.content[2].name.content[0].content, "Design Principles") 
+
+        # sec-02 content
+        self.assertIsInstance( middle.content[2].content, list)
+        self.assertEqual( len(middle.content[2].content), 5)
+        # sec-02 content[0] <T>
+        self.assertIsInstance( middle.content[2].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[0], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[0].content, list)
+        # FIXME : <T> element tail has extra space
+        self.assertEqual( len(middle.content[2].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[0].content[0].content, """
+                The use of structures that are designed to support machine readability
+                might potentially interfere with the existing ways in which protocol
+                specifications are used and authored. To the extent that these existing uses
+                are more important than machine readability, such interference must be
+                minimised.
+            """)
+        # FIXME : <T> element tail has extra space
+        self.assertIsInstance( middle.content[2].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[0].content[1], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[2].content[0].content[1].content, """
+            """)
+        # sec-02  content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[0].hangText)
+        self.assertFalse( middle.content[2].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[0].keepWithPrevious)
+
+        # sec-02 content[1] <T>
+        self.assertIsInstance( middle.content[2].content[1], rfc.T)
+        if not isinstance( middle.content[2].content[1], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[1].content, list)
+        # FIXME : <T> element tail has extra space
+        self.assertEqual( len(middle.content[2].content[1].content), 2)
+        self.assertIsInstance( middle.content[2].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[1].content[0].content, """
+                In this section, the broad design principles that underpin the format
+                described by this document are given. However, these principles apply more
+                generally to any approach that introduces structured and formal languages
+                into standards documents.
+            """)
+        # FIXME : <T> element tail has extra space
+        self.assertIsInstance( middle.content[2].content[1].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[1].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[1].content[1].content, """
+            """)
+        # sec-02  content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[1].anchor)
+        self.assertIsNone( middle.content[2].content[1].hangText)
+        self.assertFalse( middle.content[2].content[1].keepWithNext)
+        self.assertFalse( middle.content[2].content[1].keepWithPrevious)
+
+        # sec-02 content[2] <T>
+        self.assertIsInstance( middle.content[2].content[2], rfc.T)
+        if not isinstance( middle.content[2].content[2], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[2].content, list)
+        # FIXME : <T> element tail has extra space
+        self.assertEqual( len(middle.content[2].content[2].content), 2)
+        self.assertIsInstance( middle.content[2].content[2].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[2].content[0], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[2].content[2].content[0].content, """
+                It should be noted that these are design principles: they expose the
+                trade-offs that are inherent within any given approach. Violating these
+                principles is sometimes necessary and beneficial, and this document sets
+                out the potential consequences of doing so.
+            """)
+        # FIXME : <T> element tail has extra space
+        self.assertIsInstance( middle.content[2].content[2].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[2].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[2].content[1].content, """
+            """)
+        # sec-02  content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[2].anchor)
+        self.assertIsNone( middle.content[2].content[2].hangText)
+        self.assertFalse( middle.content[2].content[2].keepWithNext)
+        self.assertFalse( middle.content[2].content[2].keepWithPrevious)
+
+
+        # sec-02 content[3] <T>
+        self.assertIsInstance( middle.content[2].content[3], rfc.T)
+        if not isinstance( middle.content[2].content[3], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[3].content, list)
+        # FIXME : <T> element tail has extra space
+        self.assertEqual( len(middle.content[2].content[3].content), 2)
+        self.assertIsInstance( middle.content[2].content[3].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[3].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[3].content[0].content, """
+                The central tenet that underpins these design principles is a recognition
+                that the standardisation process is not broken, and so does not need to be
+                fixed. Failure to recognise this will likely lead to approaches that are
+                incompatible with the standards process, or that will see limited
+                adoption. However, the standards process can be improved with appropriate
+                approaches, as guided by the following broad design principles:
+            """)
+
+        # FIXME : <T> element tail has extra space
+        self.assertIsInstance( middle.content[2].content[3].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[3].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[3].content[1].content, """
+            """)
+        # sec-02  content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[3].anchor)
+        self.assertIsNone( middle.content[2].content[3].hangText)
+        self.assertFalse( middle.content[2].content[3].keepWithNext)
+        self.assertFalse( middle.content[2].content[3].keepWithPrevious)
+
+
+
+
+
+        # sec-02 content[4] <DL>
+        self.assertIsInstance( middle.content[2].content[4], rfc.DL)
+        if not isinstance( middle.content[2].content[4], rfc.DL): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[4].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content), 5)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL>
+        self.assertIsInstance( middle.content[2].content[4].content[0], tuple)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [0] <DT>
+        self.assertIsInstance( middle.content[2].content[4].content[0], tuple)
+        self.assertIsInstance( middle.content[2].content[4].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[2].content[4].content[0][0].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[2].content[4].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[0][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[0][0].content[0].content, """
+                    Most readers are human:
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[0][0].anchor)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD>
+        self.assertIsInstance( middle.content[2].content[4].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[0][1].content), 2)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[0], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[0][1].content[0].content[0].content, """
+                        Primarily, standards documents should be written for people, who
+                        require text and diagrams that they can understand. Structures that
+                        cannot be easily parsed by people should be avoided, and if
+                        included, should be clearly delineated from human-readable
+                        content.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[0][1].content[0].content[1].content, """
+                    """)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[0][1].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[0][1].content[0].hangText)
+        self.assertFalse( middle.content[2].content[4].content[0][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[0][1].content[0].keepWithPrevious)
+
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [1] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[1], rfc.T): # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[1].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[0][1].content[1].content[0].content, """
+                        Any approach that shifts this balance -- that is, that primarily
+                        targets machine readers -- is likely to be disruptive to the
+                        standardisation process, which relies upon discussion centered
+                        around documents written in prose.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[0][1].content[1].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[0][1].content[1].content[1].content, """
+                """)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[0][1].content[1].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[0][1].content[1].hangText)
+        self.assertFalse( middle.content[2].content[4].content[0][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[0][1].content[1].keepWithPrevious)
+
+        self.assertIsNone( middle.content[2].content[4].content[0][1].anchor)
+
+
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL>
+        self.assertIsInstance( middle.content[2].content[4].content[1], tuple)
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [0] <DT>
+        self.assertIsInstance( middle.content[2].content[4].content[1][0], rfc.DT)
+        self.assertIsInstance( middle.content[2].content[4].content[1][0].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[1][0].content), 1)
+        self.assertIsInstance( middle.content[2].content[4].content[1][0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[1][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[1][0].content[0].content, """
+                    Writing tools are diverse:
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[1][0].anchor)
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD>
+        self.assertIsInstance( middle.content[2].content[4].content[1][1], rfc.DD)
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[1][1].content), 2)
+        # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[0], rfc.T):  # type-check
+             return
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[0].content[0], rfc.Text):  # type-check
+             return
+        self.assertEqual( middle.content[2].content[4].content[1][1].content[0].content[0].content, """
+                        Standards document writing is a distributed process that involves a diverse set of
+                        tools and workflows. The introduction of machine-readable
+                        structures into specifications should not require that specific tools are
+                        used to produce standards documents, to ensure that disruption to
+                        existing workflows is minimised. This does not preclude the
+                        development of optional, supplementary tools that aid in the
+                        authoring machine-readable structures.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[1][1].content[0].content[1].content, """
+                    """)
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[1][1].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[1][1].content[0].hangText)
+        self.assertFalse( middle.content[2].content[4].content[1][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[1][1].content[0].keepWithPrevious)
+
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD> content [1] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[1], rfc.T):  # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[1].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[1][1].content[1].content[0].content, """
+                        The immediate impact of requiring specific tooling is that
+                        adoption is likely to be limited. A long-term impact might be that
+                        authors whose workflows are incompatible might be alienated from
+                        the process.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[1][1].content[1].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[1][1].content[1].content[1].content, """
+                """)
+        # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[1][1].content[1].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[1][1].content[1].hangText)
+        self.assertFalse( middle.content[2].content[4].content[1][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[1][1].content[1].keepWithPrevious)
+
+        self.assertIsNone( middle.content[2].content[4].content[1][1].anchor)
+
+
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL>
+        self.assertIsInstance( middle.content[2].content[4].content[2], tuple)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [0] <DT>
+        self.assertIsInstance( middle.content[2].content[4].content[2][0], rfc.DT)
+        self.assertIsInstance( middle.content[2].content[4].content[2][0].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[2][0].content), 1)
+        self.assertIsInstance( middle.content[2].content[4].content[2][0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[2][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[2][0].content[0].content, """
+                    Canonical specifications:
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[2][0].anchor)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD>
+        self.assertIsInstance( middle.content[2].content[4].content[2][1], rfc.DD)
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[2][1].content), 2)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [0] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[0], rfc.T): # type-check
+             return
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content, list)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[0].content, list): # type-check
+            return
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[0].content[0], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[2].content[4].content[2][1].content[0].content[0].content, """
+                        As far as possible, machine-readable structures should not
+                        replicate the human readable specification of the protocol
+                        within the same document. Machine-readable structures should form part
+                        of a canonical specification of the protocol. Adding supplementary
+                        machine-readable structures, in parallel to the existing
+                        human readable text, is undesirable because it creates
+                        the potential for inconsistency.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[2][1].content[0].content[1].content, """
+                    """)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[2][1].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[2][1].content[0].hangText)
+        self.assertFalse( middle.content[2].content[4].content[2][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[2][1].content[0].keepWithPrevious)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [1] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[1], rfc.T): # return
+            return
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[1].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[1].content[0], rfc.Text): #type-check
+             return
+        self.assertEqual( middle.content[2].content[4].content[2][1].content[1].content[0].content, """
+                        As an example, program code that describes how a protocol data
+                        unit can be parsed might be provided as an appendix within a
+                        standards document. This code would provide a specification of
+                        the protocol that is separate to the prose description in the
+                        main body of the document. This has the undesirable effect of
+                        introducing the potential for the program code to specify behaviour
+                        that the prose-based specification does not, and vice-versa.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[2][1].content[1].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[2][1].content[1].content[1].content, """
+                """)
+        # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[2][1].content[1].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[2][1].content[1].hangText)
+        self.assertFalse( middle.content[2].content[4].content[2][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[2][1].content[1].keepWithPrevious)
+        self.assertIsNone( middle.content[2].content[4].content[2][1].anchor)
+
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL>
+        self.assertIsInstance( middle.content[2].content[4].content[3], tuple)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [0] <DT>
+        self.assertIsInstance( middle.content[2].content[4].content[3][0], rfc.DT)
+        self.assertIsInstance( middle.content[2].content[4].content[3][0].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[3][0].content), 1)
+        self.assertIsInstance( middle.content[2].content[4].content[3][0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][0].content[0].content, """
+                    Expressiveness:
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[3][0].anchor)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD>
+        self.assertIsInstance( middle.content[2].content[4].content[3][1], rfc.DD)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content), 3)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD> content [0] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[0], rfc.T): #type-check
+            return
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[0].content[0].content, """
+                        Any approach should be expressive enough to capture the syntax
+                        and parsing process for the majority of binary protocols. If a
+                        given language is not sufficiently expressive, then adoption is
+                        likely to be limited. At the limits of what can be expressed by
+                        the language, authors are likely to revert to defining the
+                        protocol in prose: this undermines the broad goal of using
+                        structured and formal languages. Equally, though, understandable
+                        specifications and ease of use are critical for adoption. A
+                        tool that is simple to use and addresses the most common use
+                        cases might be preferred to a complex tool that addresses all
+                        use cases.
+                    """)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[0].content[1].content, """
+                    """)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[0].hangText)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[0].keepWithPrevious)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD> content [1] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[1], rfc.T): # type-check
+             return
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[1].content), 4)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[0], rfc.Text): 
+             return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[0].content, """
+                        It may be desirable to restrict expressiveness, however, to
+                        guarantee intrinsic safety, security, and computability
+                        properties of both the generated parser code for the protocol,
+                        and the parser of the description language itself. In
+                        much the same way as the language-theoretic security
+                        (""")
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[1], rfc.XRef)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[1], rfc.XRef): #type -check
+            return
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].content[1].content)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].content[1].format)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[1].content[1].pageno)
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[1].target, "LANGSEC")
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[2], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[2].content, 
+                    """) community advocates for programming
+                        language design to be informed by the desired properties of
+                        the parsers for those languages, protocol designers should be
+                        aware of the implications of their design choices. The
+                        expressiveness of the protocol description languages that they use to
+                        define their protocols can force such awareness.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[3], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[3], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[3].content, """
+                    """)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, handText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].hangText)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[1].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[1].keepWithPrevious)
+        # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD> content [2] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[2], rfc.T): # type-check
+            return
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[2].content), 4)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[0].content, """
+                        Broadly, those languages that have grammars which are more expressive tend to
+                        have parsers that are more complex and less safe. As a
+                        result, while considering the other goals described in
+                        this document, protocol description languages should attempt to be
+                        minimally expressive, and either restrict protocol designs to
+                        those for which safe and secure parsers can be generated, or
+                        as a minimum, ensure that protocol designers are aware of the boundaries their
+                        designs cross, in terms of computability and decidability """)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[1], rfc.XRef)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[1], rfc.XRef): # type-check
+             return
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].content[1].content)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].content[1].format)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[2].content[1].pageno)
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[1].target, """SASSAMAN""")
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[2], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[2].content, """.
+                    """)
+        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[3], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[3], rfc.Text):  # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[3].content, """
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].hangText)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[2].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[3][1].content[2].keepWithPrevious)
+
+        self.assertIsNone( middle.content[2].content[4].content[3][1].anchor)
+
+
+        # sec-02 content[4] <DL> content[4] <Tuple<DT,DL>
+        self.assertIsInstance( middle.content[2].content[4].content[4], tuple)
+        # sec-02 content[4] <DL> content[4] <Tuple<DT,DL> [0] <DT>
+        self.assertIsInstance( middle.content[2].content[4].content[4][0], rfc.DT)
+        self.assertIsInstance( middle.content[2].content[4].content[4][0].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[4][0].content), 1)
+        self.assertIsInstance( middle.content[2].content[4].content[4][0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[4][0].content[0], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[2].content[4].content[4][0].content[0].content, """
+                    Minimise required change:
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[4][0].anchor)
+        # sec-02 content[4] <DL> content[4] <Tuple<DT,DL> [1] <DD>
+        self.assertIsInstance( middle.content[2].content[4].content[4][1], rfc.DD)
+        self.assertIsInstance( middle.content[2].content[4].content[4][1].content, list)
+        self.assertEqual( len(middle.content[2].content[4].content[4][1].content), 1)
+        # sec-02 content[4] <DL> content[4] <Tuple<DT,DL> [1] <DD> content [0] <T>
+        self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0], rfc.T)
+        if not isinstance( middle.content[2].content[4].content[4][1].content[0], rfc.T):  # type-check
+            return
+        self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content, list)
+        # FIXME : <T>  extra line in tail 
+        self.assertEqual( len(middle.content[2].content[4].content[4][1].content[0].content), 2)
+        self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[4][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[4][1].content[0].content[0].content, """
+                        Any approach should require as few changes as possible to the way
+                        that documents are formatted, authored, and published. Forcing adoption
+                        of a particular structured or formal language is incompatible with
+                        the IETF's standardisation process: there are very few components
+                        of standards documents that are non-optional.
+                    """)
+        # FIXME : <T>  extra line in tail 
+        self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[2].content[4].content[4][1].content[0].content[1], rfc.Text):  #  type-check
+            return
+        self.assertEqual( middle.content[2].content[4].content[4][1].content[0].content[1].content, """
+                """)
+        self.assertIsNone( middle.content[2].content[4].content[4][1].content[0].anchor)
+        self.assertIsNone( middle.content[2].content[4].content[4][1].content[0].hangText)
+        self.assertFalse( middle.content[2].content[4].content[4][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[2].content[4].content[4][1].content[0].keepWithPrevious)
+        self.assertIsNone( middle.content[2].content[4].content[4][1].anchor)
+
+        # sec-02 content[4] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[2].content[4].anchor)
+        self.assertTrue( middle.content[2].content[4].hanging) 
+        self.assertEqual( middle.content[2].content[4].spacing, "normal") 
+
+
+        # sec-02 sections
+        self.assertIsInstance( middle.content[2].sections, list)
+        if not isinstance( middle.content[2].sections, list): # type-check
+            return
+        self.assertEqual( len(middle.content[2].sections), 0)
+
+        # sec-02  anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[2].anchor, "designprinciples")
+        self.assertTrue(middle.content[2].numbered)
+        self.assertFalse(middle.content[2].removeInRFC)
+        self.assertIsNone(middle.content[2].title)
+        self.assertEqual(middle.content[2].toc, "default" )
+
+
+        # sec-03
+        self.assertIsInstance(middle.content[3], rfc.Section)
+        # sec-03 name
+        self.assertIsNotNone( middle.content[3].name) 
+        self.assertIsInstance( middle.content[3].name, rfc.Name) 
+        if not isinstance( middle.content[3].name, rfc.Name) : # type-check
+            return
+        self.assertEqual( len(middle.content[3].name.content), 1) 
+        self.assertIsInstance( middle.content[3].name.content[0], rfc.Text) 
+        self.assertEqual( middle.content[3].name.content[0].content, "Augmented Packet Header Diagrams")
+
+        # sec-03 content
+        self.assertIsInstance( middle.content[3].content, list) 
+        self.assertEqual( len(middle.content[3].content), 3) 
+        # sec-03 content[0] <T>
+        self.assertIsInstance( middle.content[3].content[0], rfc.T) 
+        if not isinstance( middle.content[3].content[0], rfc.T) : # type-check
+            return
+        # sec-03 content[0] <T> content
+        self.assertIsInstance( middle.content[3].content[0].content, list) 
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].content[0].content), 4) 
+        self.assertIsInstance( middle.content[3].content[0].content[0], rfc.Text )
+        if not isinstance( middle.content[3].content[0].content[0], rfc.Text ): # type-check
+            return
+        self.assertEqual( middle.content[3].content[0].content[0].content, """
+                The design principles described in """)
+        self.assertIsInstance( middle.content[3].content[0].content[1], rfc.XRef )
+        if not isinstance( middle.content[3].content[0].content[1], rfc.XRef ): # type-check
+            return
+        self.assertIsNone( middle.content[3].content[0].content[1].content)
+        self.assertIsNone( middle.content[3].content[0].content[1].format)
+        self.assertFalse( middle.content[3].content[0].content[1].pageno)
+        self.assertEqual( middle.content[3].content[0].content[1].target, """designprinciples""")
+        self.assertIsInstance( middle.content[3].content[0].content[2], rfc.Text )
+        if not isinstance( middle.content[3].content[0].content[2], rfc.Text ): # type-check
+            return
+        self.assertEqual( middle.content[3].content[0].content[2].content,
+            """ can
+                largely be met by the existing uses of packet header diagrams. These
+                diagrams aid human readability, do not require new or specialised
+                tools to write, do not split the specification into multiple parts,
+                can express most binary protocol features, and require no changes to
+                existing publication processes.
+            """)
+        self.assertIsInstance( middle.content[3].content[0].content[3], rfc.Text )
+        if not isinstance( middle.content[3].content[0].content[3], rfc.Text ): # type-check
+            return
+        # FIXME : <T> extra line in tail
+        self.assertEqual( middle.content[3].content[0].content[3].content, """
+            """)
+        # sec-03 content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].content[0].anchor) 
+        self.assertIsNone( middle.content[3].content[0].hangText)
+        self.assertFalse( middle.content[3].content[0].keepWithNext)
+        self.assertFalse( middle.content[3].content[0].keepWithPrevious)
+
+        # sec-03 content[1] <T>
+        self.assertIsInstance( middle.content[3].content[1], rfc.T) 
+        if not isinstance( middle.content[3].content[1], rfc.T) : # type-check
+            return
+        # sec-03 content[1] <T> content
+        self.assertIsInstance( middle.content[3].content[1].content, list) 
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].content[1].content), 4) 
+        self.assertIsInstance( middle.content[3].content[1].content[0], rfc.Text )
+        if not isinstance( middle.content[3].content[1].content[0], rfc.Text ): # type-check
+            return
+        self.assertEqual( middle.content[3].content[1].content[0].content, """
+                However, as discussed in """)
+        self.assertIsInstance( middle.content[3].content[1].content[1], rfc.XRef )
+        if not isinstance( middle.content[3].content[1].content[1], rfc.XRef ): # type-check
+            return
+        self.assertIsNone( middle.content[3].content[1].content[1].content)
+        self.assertIsNone( middle.content[3].content[1].content[1].format)
+        self.assertFalse( middle.content[3].content[1].content[1].pageno)
+        self.assertEqual( middle.content[3].content[1].content[1].target, """background-ascii""")
+        self.assertIsInstance( middle.content[3].content[1].content[2], rfc.Text )
+        if not isinstance( middle.content[3].content[1].content[2], rfc.Text ): # type-check 
+            return
+        self.assertEqual( middle.content[3].content[1].content[2].content,
+            """ there are
+                limitations to how packet header diagrams are used that must be addressed if they
+                are to be parsed by machine. In this section, an augmented packet
+                header diagram format is described.
+            """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].content[1].content[3], rfc.Text )
+        if not isinstance( middle.content[3].content[1].content[3], rfc.Text ): #  type-check
+            return
+        self.assertEqual( middle.content[3].content[1].content[3].content, """
+            """)
+        # sec-03 content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].content[1].anchor) 
+        self.assertIsNone( middle.content[3].content[1].hangText)
+        self.assertFalse( middle.content[3].content[1].keepWithNext)
+        self.assertFalse( middle.content[3].content[1].keepWithPrevious)
+
+###### FROM HERE 
+        # sec-03 content[2] <T>
+        self.assertIsInstance( middle.content[3].content[2], rfc.T) 
+        if not isinstance( middle.content[3].content[2], rfc.T) : # type-check
+            return
+        # sec-03 content[2] <T> content
+        self.assertIsInstance( middle.content[3].content[2].content, list) 
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].content[2].content), 4) 
+        self.assertIsInstance( middle.content[3].content[2].content[0], rfc.Text )
+        if not isinstance( middle.content[3].content[2].content[0], rfc.Text ):
+            return
+        self.assertEqual( middle.content[3].content[2].content[0].content, """
+                The concept is first illustrated by example. This is appropriate, given the visual
+                nature of the language. In future drafts, these examples will be parsable using
+                provided tools, and a formal specification of the augmented packet
+                diagrams will be given in """)
+        self.assertIsInstance( middle.content[3].content[2].content[1], rfc.XRef )
+        if not isinstance( middle.content[3].content[2].content[1], rfc.XRef ): 
+            return
+        self.assertIsNone( middle.content[3].content[2].content[1].content)
+        self.assertIsNone( middle.content[3].content[2].content[1].format)
+        self.assertFalse( middle.content[3].content[2].content[1].pageno)
+        self.assertEqual( middle.content[3].content[2].content[1].target, """ABNF""")
+        self.assertIsInstance( middle.content[3].content[2].content[2], rfc.Text )
+        if not isinstance( middle.content[3].content[2].content[2], rfc.Text ):
+            return
+        self.assertEqual( middle.content[3].content[2].content[2].content, """.
+            """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].content[2].content[3], rfc.Text )
+        if not isinstance( middle.content[3].content[2].content[3], rfc.Text ):
+            return
+        self.assertEqual( middle.content[3].content[2].content[3].content, """
+
+            """)
+        # sec-03 content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].content[2].anchor) 
+        self.assertIsNone( middle.content[3].content[2].hangText)
+        self.assertFalse( middle.content[3].content[2].keepWithNext)
+        self.assertFalse( middle.content[3].content[2].keepWithPrevious)
+
+        # sec-03 sub-sec
+        self.assertIsInstance( middle.content[3].sections, list) 
+        if not isinstance( middle.content[3].sections, list) :
+            return
+        self.assertEqual( len(middle.content[3].sections), 10) 
+        # sec-03 sub-sec[0] 
+        self.assertIsInstance( middle.content[3].sections[0], rfc.Section)
+        # sec-03 sub-sec[0] name 
+        self.assertIsInstance( middle.content[3].sections[0].name, rfc.Name)
+        if not isinstance( middle.content[3].sections[0].name, rfc.Name): #type-check
+            return
+        self.assertIsInstance( middle.content[3].sections[0].name.content, list)
+        self.assertEqual( len(middle.content[3].sections[0].name.content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].name.content[0], rfc.Text)
+        self.assertEqual( middle.content[3].sections[0].name.content[0].content, "PDUs with Fixed and Variable-Width Fields")
+        # sec-03 sub-sec[0] content 
+        self.assertIsInstance( middle.content[3].sections[0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content), 10)
+
+        # sec-03 sub-sec[0] content [0] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[0], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[0], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [0] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[0].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[0].content), 2)
+        self.assertIsInstance( middle.content[3].sections[0].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[0].content[0], rfc.Text):
+            return
+        self.assertEqual( middle.content[3].sections[0].content[0].content[0].content, """
+                  The simplest PDU is one that contains only a set of fixed-width
+                  fields in a known order, with no optional fields or variation
+                  in the packet format.
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[0].content[1], rfc.Text):
+             return
+        self.assertEqual( middle.content[3].sections[0].content[0].content[1].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[0].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[0].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[0].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[0].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [1] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[1], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[1], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [1] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[1].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[1].content), 2)
+        self.assertIsInstance( middle.content[3].sections[0].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[1].content[0], rfc.Text): #type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[1].content[0].content, """
+                  Some packet formats include variable-width fields, where
+                  the size of a field is either derived from the value of
+                  some previous field, or is unspecified and inferred from
+                  the total size of the packet and the size of the other
+                  fields.
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[1].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[1].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[1].content[1].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[1].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[1].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[1].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[1].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [2] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[2], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[2], rfc.T):  # type-check
+            return
+        # sec-03 sub-sec[0] content [2] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[2].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[2].content), 2)
+        self.assertIsInstance( middle.content[3].sections[0].content[2].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[2].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[2].content[0].content, """
+                  To ensure that there is no ambiguity, a PDU description
+                  can contain only one field whose length is unspecified.
+                  The length of a single field, where all other fields are
+                  of known (but perhaps variable) length, can be inferred
+                  from the total size of the containing PDU.
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[2].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[2].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[2].content[1].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [2] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[2].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[2].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[2].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[2].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [3] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[3], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[3], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [3] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[3].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[3].content), 2)
+        self.assertIsInstance( middle.content[3].sections[0].content[3].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[3].content[0], rfc.Text): #  type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[3].content[0].content, """
+                  A PDU description is introduced by the exact phrase "A/An
+                  _______ is formatted as follows:" at the end of a paragraph.
+                  This is followed by the PDU description itself, as a packet
+                  diagram within an <artwork> element in the XML representation,
+                  starting with a header line to show the bit width of the diagram.
+                  The description of the fields follows the diagram, as an XML
+                  <dl> list, after a paragraph containing the text "where:".
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[3].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[3].content[1], rfc.Text):  # type-check
+             return
+        self.assertEqual( middle.content[3].sections[0].content[3].content[1].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [3] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[3].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[3].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[3].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[3].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [4] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[4], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[4], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [4] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[4].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[4].content), 4)
+        self.assertIsInstance( middle.content[3].sections[0].content[4].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[4].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[4].content[0].content, """
+                  PDU names must be unique, both within a document, and across
+                  all documents that are linked together (i.e., using the
+                  structured language defined in """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[4].content[1], rfc.XRef)
+        if not isinstance( middle.content[3].sections[0].content[4].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[3].sections[0].content[4].content[1].content)
+        self.assertIsNone( middle.content[3].sections[0].content[4].content[1].format)
+        self.assertFalse( middle.content[3].sections[0].content[4].content[1].pageno)
+        self.assertEqual( middle.content[3].sections[0].content[4].content[1].target, """ascii-import""")
+        self.assertIsInstance( middle.content[3].sections[0].content[4].content[2], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[4].content[2], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[4].content[2].content, """).
+                """)
+        self.assertIsInstance( middle.content[3].sections[0].content[4].content[3], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[4].content[3], rfc.Text): # type-check
+            return
+        # FIXME : <T> extra line in tail
+        self.assertEqual( middle.content[3].sections[0].content[4].content[3].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [4] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[4].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[4].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[4].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[4].keepWithPrevious)
+
+
+
+        # sec-03 sub-sec[0] content [5] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[5], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[5], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [5] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[5].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[5].content), 4)
+        self.assertIsInstance( middle.content[3].sections[0].content[5].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[5].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[5].content[0].content, """
+                  Each field of the description starts with a <dt> tag
+                  comprising the field name and an optional short name in
+                  parenthesis. These are followed by a colon, the field
+                  length, an optional presence expression (described in
+                  """)
+        self.assertIsInstance( middle.content[3].sections[0].content[5].content[1], rfc.XRef)
+        if not isinstance( middle.content[3].sections[0].content[5].content[1], rfc.XRef): # type-check
+             return
+        self.assertIsNone( middle.content[3].sections[0].content[5].content[1].content)
+        self.assertIsNone( middle.content[3].sections[0].content[5].content[1].format)
+        self.assertFalse( middle.content[3].sections[0].content[5].content[1].pageno)
+        self.assertEqual( middle.content[3].sections[0].content[5].content[1].target, """ascii-xref""")
+        self.assertIsInstance( middle.content[3].sections[0].content[5].content[2], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[5].content[2], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[3].sections[0].content[5].content[2].content,
+                """), and a terminating period. The following <dd>
+                  tag contains a prose description of the field. Field names
+                  cannot be the same as a previously defined PDU name, and must
+                  be unique within a given structure definition.
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[5].content[3], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[5].content[3], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[5].content[3].content, """
+
+                """)
+        # sec-03 sub-sec[0] content [5] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[5].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[5].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[5].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[5].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [6] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[6], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[6], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [6] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[6].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[6].content), 4)
+        self.assertIsInstance( middle.content[3].sections[0].content[6].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[6].content[0], rfc.Text) : # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[6].content[0].content, """
+                 For example, this can be illustrated using the IPv4 Header
+                 Format """)
+        self.assertIsInstance( middle.content[3].sections[0].content[6].content[1], rfc.XRef)
+        if not isinstance( middle.content[3].sections[0].content[6].content[1], rfc.XRef): # type-check
+            return
+        self.assertIsNone( middle.content[3].sections[0].content[6].content[1].content)
+        self.assertIsNone( middle.content[3].sections[0].content[6].content[1].format)
+        self.assertFalse( middle.content[3].sections[0].content[6].content[1].pageno)
+        self.assertEqual( middle.content[3].sections[0].content[6].content[1].target, """RFC791""")
+        self.assertIsInstance( middle.content[3].sections[0].content[6].content[2], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[6].content[2], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[6].content[2].content,
+                """. An IPv4 Header is formatted
+                 as follows:
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[6].content[3], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[6].content[3], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[3].sections[0].content[6].content[3].content, """
+                """)
+        # sec-03 sub-sec[0] content [6] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[6].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[6].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[6].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[6].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [7] <Artwork>
+        self.assertIsInstance( middle.content[3].sections[0].content[7], rfc.Artwork)
+        if not isinstance( middle.content[3].sections[0].content[7], rfc.Artwork): # type-check
+            return
+        # sec-03 sub-sec[0] content [7] <Artwork> content
+        self.assertIsInstance( middle.content[3].sections[0].content[7].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[7].content, rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[7].content.content, """
+     0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |Version|   IHL |    DSCP   |ECN|         Total Length          |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |         Identification        |Flags|     Fragment Offset     |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    | Time to Live  |    Protocol   |        Header Checksum        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                         Source Address                        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                      Destination Address                      |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                            Options                          ...
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               :
+    :                            Payload                            :
+    :                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                """)
+        # sec-03 sub-sec[0] content [7] <Artwork> align, alt, anchor, height, name, src, type, width, xmlSpace
+        self.assertEqual( middle.content[3].sections[0].content[7].align , "left" )
+        self.assertIsNone( middle.content[3].sections[0].content[7].alt)
+        self.assertIsNone( middle.content[3].sections[0].content[7].anchor)
+        self.assertIsNone( middle.content[3].sections[0].content[7].height)
+        self.assertIsNone( middle.content[3].sections[0].content[7].name)
+        self.assertIsNone( middle.content[3].sections[0].content[7].src)
+        self.assertIsNone( middle.content[3].sections[0].content[7].type)
+        self.assertIsNone( middle.content[3].sections[0].content[7].width)
+        self.assertIsNone( middle.content[3].sections[0].content[7].xmlSpace)
+
+        # sec-03 sub-sec[0] content [8] <T>
+        self.assertIsInstance( middle.content[3].sections[0].content[8], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[8], rfc.T):  # type-check
+            return
+        # sec-03 sub-sec[0] content [8] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[8].content, list)
+        # FIXME : <T> extra line in tail
+        self.assertEqual( len(middle.content[3].sections[0].content[8].content), 2)
+        self.assertIsInstance( middle.content[3].sections[0].content[8].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[8].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[8].content[0].content, """
+                    where:
+                """)
+        # FIXME : <T> extra line in tail
+        self.assertIsInstance( middle.content[3].sections[0].content[8].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[8].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[8].content[1].content, """
+                """)
+        # sec-03 sub-sec[0] content [8] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[8].anchor) 
+        self.assertIsNone( middle.content[3].sections[0].content[8].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[8].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[8].keepWithPrevious)
+
+        # sec-03 sub-sec[0] content [9] <DL>
+        self.assertIsInstance( middle.content[3].sections[0].content[9], rfc.DL)
+        if not isinstance( middle.content[3].sections[0].content[9], rfc.DL) : # type-check
+            return
+        # sec-03 sub-sec[0] content [9] <DL> content 
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content), 15)
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # DJ section-03 subsection[0] content[9] DL --- continue 
+        # sec-03 sub-sec[0] content [9] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[0].content[9].anchor)
+        self.assertTrue( middle.content[3].sections[0].content[9].hanging) 
+        self.assertEqual( middle.content[3].sections[0].content[9].spacing, "normal") 
+
+        # sec-03 sub-sec[0] sections 
+        self.assertIsInstance( middle.content[3].sections[0].sections, list)
+        if not isinstance( middle.content[3].sections[0].sections, list): # type-check
+            return
+        self.assertEqual( len(middle.content[3].sections[0].sections), 0)
+        # sec-03  sub-sec[0] anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[3].sections[0].anchor, "ascii-simple")
+        self.assertTrue(middle.content[3].sections[0].numbered)
+        self.assertFalse(middle.content[3].sections[0].removeInRFC)
+        self.assertIsNone(middle.content[3].sections[0].title)
+        self.assertEqual(middle.content[3].sections[0].toc, "default")
+
+        # sec-03 sub-sec[1] 
+        self.assertIsInstance( middle.content[3].sections[1], rfc.Section)
+        # sec-03 sub-sec[2] 
+        self.assertIsInstance( middle.content[3].sections[2], rfc.Section)
+        # sec-03 sub-sec[3] 
+        self.assertIsInstance( middle.content[3].sections[3], rfc.Section)
+        # sec-03 sub-sec[4] 
+        self.assertIsInstance( middle.content[3].sections[4], rfc.Section)
+        # sec-03 sub-sec[5] 
+        self.assertIsInstance( middle.content[3].sections[5], rfc.Section)
+        # sec-03 sub-sec[6] 
+        self.assertIsInstance( middle.content[3].sections[6], rfc.Section)
+        # sec-03 sub-sec[7] 
+        self.assertIsInstance( middle.content[3].sections[7], rfc.Section)
+        # sec-03 sub-sec[8] 
+        self.assertIsInstance( middle.content[3].sections[8], rfc.Section)
+        # sec-03 sub-sec[9] 
+        self.assertIsInstance( middle.content[3].sections[9], rfc.Section)
+
+#----------
+        # DJ section-03 
+#----------
+
+
+
+        # sec-03  anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[3].anchor, "augmentedascii")
+        self.assertTrue(middle.content[3].numbered)
+        self.assertFalse(middle.content[3].removeInRFC)
+        self.assertIsNone(middle.content[3].title)
+        self.assertEqual(middle.content[3].toc, "default" )
+        # ...
+        self.assertIsInstance(middle.content[4], rfc.Section)
+        # ...
+        self.assertIsInstance(middle.content[5], rfc.Section)
+        # ...
+        self.assertIsInstance(middle.content[6], rfc.Section)
+        # ...
+        self.assertIsInstance(middle.content[7], rfc.Section)
+        # ...
+

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -1915,8 +1915,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[0].sections[1].content[0].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone(back.sections[0].sections[1].content[0].content[1].content)
-        # FIXME : should default to "default" RFC7991 2.66.1
-        self.assertIsNone(back.sections[0].sections[1].content[0].content[1].format)
+        self.assertEqual(back.sections[0].sections[1].content[0].content[1].format, "default")
         self.assertFalse(back.sections[0].sections[1].content[0].content[1].pageno)
         self.assertEqual(back.sections[0].sections[1].content[0].content[1].target, "augmentedascii")
         self.assertIsInstance(back.sections[0].sections[1].content[0].content[2], rfc.Text)
@@ -1931,8 +1930,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[0].sections[1].content[0].content[3], rfc.XRef): # type-check
             return
         self.assertIsNone(back.sections[0].sections[1].content[0].content[3].content)
-        # FIXME : should default to "default" RFC7991 2.66.1
-        self.assertIsNone(back.sections[0].sections[1].content[0].content[3].format)
+        self.assertEqual(back.sections[0].sections[1].content[0].content[3].format, "default")
         self.assertFalse(back.sections[0].sections[1].content[0].content[3].pageno)
         self.assertEqual(back.sections[0].sections[1].content[0].content[3].target, "augmentedascii")
         self.assertIsInstance(back.sections[0].sections[1].content[0].content[4], rfc.Text)
@@ -2125,8 +2123,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[0].content[1].content[1], rfc.XRef):  #type-check
             return
         self.assertIsNone( middle.content[0].content[1].content[1].content)
-        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
-        self.assertIsNone( middle.content[0].content[1].content[1].format)
+        self.assertEqual( middle.content[0].content[1].content[1].format, "default")
         self.assertFalse( middle.content[0].content[1].content[1].pageno)
         self.assertEqual( middle.content[0].content[1].content[1].target, "tcp-header-format")
         self.assertIsInstance( middle.content[0].content[1].content[2], rfc.Text) 
@@ -2166,8 +2163,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[0].content[2].name.content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[0].content[2].name.content[1].content)
-        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
-        self.assertIsNone( middle.content[0].content[2].name.content[1].format)
+        self.assertEqual( middle.content[0].content[2].name.content[1].format, "default")
         self.assertFalse( middle.content[0].content[2].name.content[1].pageno)
         self.assertEqual( middle.content[0].content[2].name.content[1].target, "RFC793")
         # sec-00  content[2] <Figure>  irefs
@@ -2327,7 +2323,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertIsNone( middle.content[0].content[6].content[1].content)
         #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
-        self.assertIsNone( middle.content[0].content[6].content[1].format)
+        self.assertEqual( middle.content[0].content[6].content[1].format, "default")
         self.assertFalse( middle.content[0].content[6].content[1].pageno)
         self.assertEqual( middle.content[0].content[6].content[1].target, "ABNF")
         self.assertIsInstance( middle.content[0].content[6].content[2], rfc.Text)
@@ -2338,8 +2334,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[0].content[6].content[3], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[0].content[6].content[3].content)
-        #FIXME :  format defaults to "default" RFC 7991 sec 2.66.1
-        self.assertIsNone( middle.content[0].content[6].content[3].format)
+        self.assertEqual( middle.content[0].content[6].content[3].format, "default")
         self.assertFalse( middle.content[0].content[6].content[3].pageno)
         self.assertEqual( middle.content[0].content[6].content[3].target, "source")
         self.assertIsInstance( middle.content[0].content[6].content[4], rfc.Text)
@@ -2463,7 +2458,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[0].name.content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[0].name.content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[0].name.content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[0].name.content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[0].name.content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[0].name.content[1].target, "QUIC-TRANSPORT")
         # sec-01  sub-sec[0] content[0] <Figure> irefs
@@ -2553,7 +2548,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( middle.content[1].sections[0].content[1].content[1], rfc.XRef)
         if not isinstance( middle.content[1].sections[0].content[1].content[1], rfc.XRef): # type-check
             return
-        self.assertIsNone( middle.content[1].sections[0].content[1].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[1].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[1].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[1].content[1].target, "quic-reset-stream")
         self.assertIsInstance( middle.content[1].sections[0].content[1].content[2], rfc.Text)
@@ -2652,7 +2647,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[1].target, "quic-reset-stream")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[2], rfc.Text)
@@ -2671,7 +2666,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[3].target, "dhcpv6-relaysrcopt")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[4], rfc.Text)
@@ -2689,7 +2684,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[5].target, "RFC6958")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[6], rfc.Text)
@@ -2723,7 +2718,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[1].target, "quic-reset-stream")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[2], rfc.Text)
@@ -2735,7 +2730,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[3].target, "dhcpv6-relaysrcopt")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[4], rfc.Text)
@@ -2787,7 +2782,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[1][1].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[1][1].content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[1][1].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[1][1].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[1][1].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[1][1].content[1].target, "dhcpv6-relaysrcopt")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[1][1].content[2], rfc.Text)
@@ -2859,7 +2854,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[1].target, "quic-reset-stream")
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[2], rfc.Text)
@@ -2920,7 +2915,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[1].target, "RFC3550")
         # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[2] <Text>
@@ -2967,7 +2962,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[4].name.content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[0].content[4].name.content[1].content)
-        self.assertIsNone( middle.content[1].sections[0].content[4].name.content[1].format)
+        self.assertEqual( middle.content[1].sections[0].content[4].name.content[1].format, "default")
         self.assertFalse( middle.content[1].sections[0].content[4].name.content[1].pageno)
         self.assertEqual( middle.content[1].sections[0].content[4].name.content[1].target, "RFC8357")
         # sec-01  sub-sec[0] content[4] <Figure> irefs
@@ -3075,7 +3070,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[1].content[0].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[1].content[0].content[1].content)
-        self.assertIsNone( middle.content[1].sections[1].content[0].content[1].format)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[1].format, "default")
         self.assertFalse( middle.content[1].sections[1].content[0].content[1].pageno)
         self.assertEqual( middle.content[1].sections[1].content[0].content[1].target, "RFC5234")
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[2], rfc.Text)
@@ -3087,7 +3082,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[1].content[0].content[3], rfc.XRef):  # type-check
              return
         self.assertIsNone( middle.content[1].sections[1].content[0].content[3].content)
-        self.assertIsNone( middle.content[1].sections[1].content[0].content[3].format)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[3].format, "default")
         self.assertFalse( middle.content[1].sections[1].content[0].content[3].pageno)
         self.assertEqual( middle.content[1].sections[1].content[0].content[3].target, "ASN1")
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[4], rfc.Text)
@@ -3098,7 +3093,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[1].content[0].content[5], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[1].content[0].content[5].content)
-        self.assertIsNone( middle.content[1].sections[1].content[0].content[5].format)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[5].format, "default")
         self.assertFalse( middle.content[1].sections[1].content[0].content[5].pageno)
         self.assertEqual( middle.content[1].sections[1].content[0].content[5].target, "RFC7049")
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[6], rfc.Text)
@@ -3110,7 +3105,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[1].content[0].content[7], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[1].content[0].content[7].content)
-        self.assertIsNone( middle.content[1].sections[1].content[0].content[7].format)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[7].format, "default")
         self.assertFalse( middle.content[1].sections[1].content[0].content[7].pageno)
         self.assertEqual( middle.content[1].sections[1].content[0].content[7].target, "RFC8446")
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[8], rfc.Text)
@@ -3122,7 +3117,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[1].content[0].content[9], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[1].sections[1].content[0].content[9].content)
-        self.assertIsNone( middle.content[1].sections[1].content[0].content[9].format)
+        self.assertEqual( middle.content[1].sections[1].content[0].content[9].format, "default")
         self.assertFalse( middle.content[1].sections[1].content[0].content[9].pageno)
         self.assertEqual( middle.content[1].sections[1].content[0].content[9].target, "RFC7950")
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[10], rfc.Text)
@@ -3533,7 +3528,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[1], rfc.XRef): #type -check
             return
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].content[1].content)
-        self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].content[1].format)
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[1].format, "default")
         self.assertFalse( middle.content[2].content[4].content[3][1].content[1].content[1].pageno)
         self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[1].target, "LANGSEC")
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[2], rfc.Text)
@@ -3573,7 +3568,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[1], rfc.XRef): # type-check
              return
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].content[1].content)
-        self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].content[1].format)
+        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[1].format, "default")
         self.assertFalse( middle.content[2].content[4].content[3][1].content[2].content[1].pageno)
         self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[1].target, """SASSAMAN""")
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[2], rfc.Text)
@@ -3678,7 +3673,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].content[0].content[1], rfc.XRef ): # type-check
             return
         self.assertIsNone( middle.content[3].content[0].content[1].content)
-        self.assertIsNone( middle.content[3].content[0].content[1].format)
+        self.assertEqual( middle.content[3].content[0].content[1].format, "default")
         self.assertFalse( middle.content[3].content[0].content[1].pageno)
         self.assertEqual( middle.content[3].content[0].content[1].target, """designprinciples""")
         self.assertIsInstance( middle.content[3].content[0].content[2], rfc.Text )
@@ -3714,7 +3709,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].content[1].content[1], rfc.XRef ): # type-check
             return
         self.assertIsNone( middle.content[3].content[1].content[1].content)
-        self.assertIsNone( middle.content[3].content[1].content[1].format)
+        self.assertEqual( middle.content[3].content[1].content[1].format, "default")
         self.assertFalse( middle.content[3].content[1].content[1].pageno)
         self.assertEqual( middle.content[3].content[1].content[1].target, """background-ascii""")
         self.assertIsInstance( middle.content[3].content[1].content[2], rfc.Text )
@@ -3751,7 +3746,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].content[2].content[1], rfc.XRef ): 
             return
         self.assertIsNone( middle.content[3].content[2].content[1].content)
-        self.assertIsNone( middle.content[3].content[2].content[1].format)
+        self.assertEqual( middle.content[3].content[2].content[1].format, "default")
         self.assertFalse( middle.content[3].content[2].content[1].pageno)
         self.assertEqual( middle.content[3].content[2].content[1].target, """ABNF""")
         self.assertIsInstance( middle.content[3].content[2].content[2], rfc.Text )
@@ -3896,7 +3891,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].sections[0].content[4].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[3].sections[0].content[4].content[1].content)
-        self.assertIsNone( middle.content[3].sections[0].content[4].content[1].format)
+        self.assertEqual( middle.content[3].sections[0].content[4].content[1].format, "default")
         self.assertFalse( middle.content[3].sections[0].content[4].content[1].pageno)
         self.assertEqual( middle.content[3].sections[0].content[4].content[1].target, """ascii-import""")
         self.assertIsInstance( middle.content[3].sections[0].content[4].content[2], rfc.Text)
@@ -3932,7 +3927,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].sections[0].content[5].content[1], rfc.XRef): # type-check
              return
         self.assertIsNone( middle.content[3].sections[0].content[5].content[1].content)
-        self.assertIsNone( middle.content[3].sections[0].content[5].content[1].format)
+        self.assertEqual( middle.content[3].sections[0].content[5].content[1].format, "default")
         self.assertFalse( middle.content[3].sections[0].content[5].content[1].pageno)
         self.assertEqual( middle.content[3].sections[0].content[5].content[1].target, """ascii-xref""")
         self.assertIsInstance( middle.content[3].sections[0].content[5].content[2], rfc.Text)
@@ -3967,7 +3962,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].sections[0].content[6].content[1], rfc.XRef): # type-check
             return
         self.assertIsNone( middle.content[3].sections[0].content[6].content[1].content)
-        self.assertIsNone( middle.content[3].sections[0].content[6].content[1].format)
+        self.assertEqual( middle.content[3].sections[0].content[6].content[1].format, "default")
         self.assertFalse( middle.content[3].sections[0].content[6].content[1].pageno)
         self.assertEqual( middle.content[3].sections[0].content[6].content[1].target, """RFC791""")
         self.assertIsInstance( middle.content[3].sections[0].content[6].content[2], rfc.Text)
@@ -4449,7 +4444,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].sections[0].content[9].content[13][1].content[1], rfc.XRef):# type-check
             return
         self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].content[1].content)
-        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].content[1].format)
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[1].format, "default")
         self.assertFalse( middle.content[3].sections[0].content[9].content[13][1].content[1].pageno)
         self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[1].target, """ABNF-constraints""")
         self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content[2], rfc.Text)

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -80,8 +80,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertFalse(node.sortRefs)
         self.assertEqual(node.submissionType, "IETF")
         self.assertTrue(node.symRefs)
-        # FIXME - RFC7991 2.45.14  - default should be "3"
-        self.assertEqual(node.tocDepth, None)   # FixMe - RFC7991 2.45.14
+        self.assertEqual(node.tocDepth,"3")
         self.assertTrue(node.tocInclude)
         self.assertIsNone(node.updates)
         self.assertEqual(node.version, "3")
@@ -1893,7 +1892,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # section-00 -- (sub) section 01
         self.assertIsInstance(back.sections[0].sections[1], rfc.Section)
         # section-00 -- (sub) section 01 name
-        # FIXME : parse_section line 975 : name is not parsed
         self.assertIsInstance(back.sections[0].sections[1].name, rfc.Name)
         if not isinstance(back.sections[0].sections[1].name, rfc.Name): # type-check
             return

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -413,7 +413,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[0].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[0].content[0].status)
         self.assertEqual      ( back.refs[0].content[0].content[0].value,      "8357")
-        self.assertIsNone     ( back.refs[0].content[0].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[0].content[0].stream,     "IETF")
 
         # reference -- 00 - anchor
         self.assertEqual(back.refs[0].content[0].anchor, "RFC8357")
@@ -518,7 +518,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[1].content[0].name,       "Internet-Draft")
         self.assertIsNone     ( back.refs[0].content[1].content[0].status)
         self.assertEqual      ( back.refs[0].content[1].content[0].value,      "draft-ietf-quic-transport-27")
-        self.assertIsNone     ( back.refs[0].content[1].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[1].content[0].stream,     "IETF")
 
         # reference -- 01 - anchor
         self.assertEqual(back.refs[0].content[1].anchor, "QUIC-TRANSPORT")
@@ -652,7 +652,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[2].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[2].content[0].status)
         self.assertEqual      ( back.refs[0].content[2].content[0].value,      "6958")
-        self.assertIsNone     ( back.refs[0].content[2].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[2].content[0].stream,     "IETF")
 
         # reference -- 02 - anchor
         self.assertEqual(back.refs[0].content[2].anchor, "RFC6958")
@@ -742,7 +742,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[3].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[3].content[0].status)
         self.assertEqual      ( back.refs[0].content[3].content[0].value,      "7950")
-        self.assertIsNone     ( back.refs[0].content[3].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[3].content[0].stream,     "IETF")
 
         # reference -- 03 - anchor
         self.assertEqual(back.refs[0].content[3].anchor, "RFC7950")
@@ -831,7 +831,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[4].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[4].content[0].status)
         self.assertEqual      ( back.refs[0].content[4].content[0].value,      "8446")
-        self.assertIsNone     ( back.refs[0].content[4].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[4].content[0].stream,     "IETF")
 
         # reference -- 04 - anchor
         self.assertEqual(back.refs[0].content[4].anchor, "RFC8446")
@@ -925,7 +925,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
 
         # reference -- 05 - seriesInfo
         self.assertIsInstance( back.refs[0].content[5].content,list)
-        # FIXME : parser_rfc_xml.py line 1324 seriesinfo -> seriesInfo
         self.assertEqual(len(back.refs[0].content[5].content), 1)
 
         self.assertIsInstance ( back.refs[0].content[5].content[0],            rfc.SeriesInfo)
@@ -936,7 +935,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[5].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[5].content[0].status)
         self.assertEqual      ( back.refs[0].content[5].content[0].value,      "5234")
-        self.assertIsNone     ( back.refs[0].content[5].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[5].content[0].stream,     "IETF")
 
         # reference -- 05 - anchor
         self.assertEqual(back.refs[0].content[5].anchor, "RFC5234")
@@ -1009,7 +1008,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
 
         # reference -- 06 - seriesInfo
         self.assertIsInstance( back.refs[0].content[6].content,list)
-        # FIXME : parser_rfc_xml.py line 1324 seriesinfo -> seriesInfo
         self.assertEqual(len(back.refs[0].content[6].content), 1)
 
         self.assertIsInstance ( back.refs[0].content[6].content[0],            rfc.SeriesInfo)
@@ -1020,7 +1018,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[6].content[0].name,       "ITU-T Recommendation")
         self.assertIsNone     ( back.refs[0].content[6].content[0].status)
         self.assertEqual      ( back.refs[0].content[6].content[0].value,      "X.680, X.681, X.682, and X.683")
-        self.assertIsNone     ( back.refs[0].content[6].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[6].content[0].stream,     "IETF")
 
         # reference -- 06 - anchor
         self.assertEqual(back.refs[0].content[6].anchor, "ASN1")
@@ -1123,7 +1121,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[7].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[7].content[0].status)
         self.assertEqual      ( back.refs[0].content[7].content[0].value,      "7049")
-        self.assertIsNone     ( back.refs[0].content[7].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[7].content[0].stream,     "IETF")
 
         # reference -- 07 - anchor
         self.assertEqual(back.refs[0].content[7].anchor, "RFC7049")
@@ -1248,7 +1246,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
 
         # reference -- 08 - seriesInfo
         self.assertIsInstance( back.refs[0].content[8].content,list)
-        # FIXME : parser_rfc_xml.py line 1324 seriesinfo -> seriesInfo
         self.assertEqual(len(back.refs[0].content[8].content), 1)
 
         self.assertIsInstance ( back.refs[0].content[8].content[0],            rfc.SeriesInfo)
@@ -1259,7 +1256,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[8].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[8].content[0].status)
         self.assertEqual      ( back.refs[0].content[8].content[0].value,      "3550")
-        self.assertIsNone     ( back.refs[0].content[8].content[0].stream)
+        self.assertEqual       ( back.refs[0].content[8].content[0].stream,     "IETF")
 
         # reference -- 08 - anchor
         self.assertEqual(back.refs[0].content[8].anchor, "RFC3550")
@@ -1422,7 +1419,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[9].content[0].name,       "Internet-Draft")
         self.assertIsNone     ( back.refs[0].content[9].content[0].status)
         self.assertEqual      ( back.refs[0].content[9].content[0].value,      "draft-ietf-tram-stunbis-21")
-        self.assertIsNone     ( back.refs[0].content[9].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[9].content[0].stream,     "IETF")
 
         # reference -- 09 - anchor
         self.assertEqual(back.refs[0].content[9].anchor, "draft-ietf-tram-stunbis-21")
@@ -1511,7 +1508,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[10].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[10].content[0].status)
         self.assertEqual      ( back.refs[0].content[10].content[0].value,      "791")
-        self.assertIsNone     ( back.refs[0].content[10].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[10].content[0].stream,     "IETF")
 
         # reference -- 10 - anchor
         self.assertEqual(back.refs[0].content[10].anchor, "RFC791")
@@ -1591,7 +1588,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
 
         # reference -- 11 - seriesInfo
         self.assertIsInstance( back.refs[0].content[11].content,list)
-        # FIXME : parser_rfc_xml.py line 1324 seriesinfo -> seriesInfo
         self.assertEqual(len(back.refs[0].content[11].content), 1)
 
         self.assertIsInstance ( back.refs[0].content[11].content[0],            rfc.SeriesInfo)
@@ -1602,7 +1598,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual      ( back.refs[0].content[11].content[0].name,       "RFC")
         self.assertIsNone     ( back.refs[0].content[11].content[0].status)
         self.assertEqual      ( back.refs[0].content[11].content[0].value,      "793")
-        self.assertIsNone     ( back.refs[0].content[11].content[0].stream)
+        self.assertEqual      ( back.refs[0].content[11].content[0].stream,     "IETF")
 
         # reference -- 11 - anchor
         self.assertEqual(back.refs[0].content[11].anchor, "RFC793")

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -245,8 +245,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( node.abstract.content[0] , rfc.T)
         self.assertIsInstance( node.abstract.content[0].content , list)
 
-        # FIXME : Only one paragraph should be here. Parser should eliminate next empty new-lines
-        self.assertEqual     ( len(node.abstract.content[0].content) , 2)
+        self.assertEqual     ( len(node.abstract.content[0].content) , 1)
         self.assertIsInstance( node.abstract.content[0].content[0] , rfc.Text)
         if not isinstance( node.abstract.content[0].content[0], rfc.Text) :
             return
@@ -1910,11 +1909,10 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertIsInstance(back.sections[0].sections[1].content[0].content, list)
 
-        self.assertEqual(len(back.sections[0].sections[1].content[0].content), 6)
+        self.assertEqual(len(back.sections[0].sections[1].content[0].content), 5)
         self.assertIsInstance(back.sections[0].sections[1].content[0].content[0], rfc.Text)
         if not isinstance(back.sections[0].sections[1].content[0].content[0], rfc.Text): # type-check
             return
-        #FIXME -- lstrip and rstrip each text ?
         self.assertEqual(back.sections[0].sections[1].content[0].content[0].content, """
                     Future revisions of this draft will include an ABNF specification for
                     the augmented packet diagram format described in
@@ -1930,7 +1928,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance(back.sections[0].sections[1].content[0].content[2], rfc.Text)
         if not isinstance(back.sections[0].sections[1].content[0].content[2], rfc.Text): # type-check
             return
-        #FIXME -- lstrip and rstrip each text ?
         self.assertEqual(back.sections[0].sections[1].content[0].content[2].content, """. Such a specification is omitted from
                     this draft given that the format is likely to change as its syntax is
                     developed. Given the visual nature of the format, it is more
@@ -1947,15 +1944,8 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance(back.sections[0].sections[1].content[0].content[4], rfc.Text)
         if not isinstance(back.sections[0].sections[1].content[0].content[4], rfc.Text): # type-check
             return
-        #FIXME -- lstrip and rstrip each text ?
         self.assertEqual(back.sections[0].sections[1].content[0].content[4].content, """.
                 """)
-        self.assertIsInstance(back.sections[0].sections[1].content[0].content[5], rfc.Text)
-        if not isinstance(back.sections[0].sections[1].content[0].content[5], rfc.Text): # type-check
-            return
-        #FIXME -- This extra newline -- where does it come from ? -- looks like the tail of the paragraph
-        self.assertEqual(back.sections[0].sections[1].content[0].content[5].content, """
-            """)
 
 
         # section-00 -- (sub) section 00 -- content -- anchor, hangText , keepWithNext, keepWithPrevious
@@ -2002,7 +1992,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[1].content[0], rfc.T): # type-check
             return
         self.assertIsInstance(back.sections[1].content[0].content, list)
-        self.assertEqual(len(back.sections[1].content[0].content), 4)
+        self.assertEqual(len(back.sections[1].content[0].content), 3)
         # section-01 content[0] content[0]
         self.assertIsInstance(back.sections[1].content[0].content[0], rfc.Text)
         if not isinstance(back.sections[1].content[0].content[0], rfc.Text): # type-check
@@ -2022,12 +2012,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertEqual(back.sections[1].content[0].content[2].content, """.
             """)
-        # section-01 content[0] content[3]
-        self.assertIsInstance(back.sections[1].content[0].content[3], rfc.Text)
-        if not isinstance(back.sections[1].content[0].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual(back.sections[1].content[0].content[3].content, """
-            """)
 
         # section-01 content[0] anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone(back.sections[1].content[0].anchor)
@@ -2041,7 +2025,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance(back.sections[1].content[1], rfc.T): # type-check
             return
         self.assertIsInstance(back.sections[1].content[1].content, list)
-        self.assertEqual(len(back.sections[1].content[1].content), 4)
+        self.assertEqual(len(back.sections[1].content[1].content), 3)
         # section-01 content[1] content[0]
         self.assertIsInstance(back.sections[1].content[1].content[0], rfc.Text)
         if not isinstance(back.sections[1].content[1].content[0], rfc.Text): # type-check
@@ -2061,12 +2045,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertEqual(back.sections[1].content[1].content[2].content, """.
             """)
-        # section-01 content[0] content[3]
-        self.assertIsInstance(back.sections[1].content[1].content[3], rfc.Text)
-        if not isinstance(back.sections[1].content[1].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual(back.sections[1].content[1].content[3].content, """
-        """)
 
 
         # section-01 content[0] anchor, hangText, keepWithNext, keepWithPrevious
@@ -2119,8 +2097,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[0] <T>  Text
         self.assertIsInstance( middle.content[0].content[0].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[0].content), 2)
+        self.assertEqual( len(middle.content[0].content[0].content), 1)
         self.assertIsInstance( middle.content[0].content[0].content[0], rfc.Text)
         if not isinstance(middle.content[0].content[0].content[0], rfc.Text):  # type-check
             return
@@ -2130,12 +2107,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 documents, they allow for the visualisation of packet formats, reducing
                 human error, and aiding in the implementation of parsers for the protocols
                 that they specify.
-            """)
-        #FIXME - unnecessary empty tag 
-        self.assertIsInstance(middle.content[0].content[0].content[1], rfc.Text) 
-        if not isinstance(middle.content[0].content[0].content[1], rfc.Text) : # type-check
-            return
-        self.assertEqual(middle.content[0].content[0].content[1].content, """
             """)
         # sec-00  content[0] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[0].anchor)
@@ -2150,8 +2121,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[1] <T>  Text
         self.assertIsInstance( middle.content[0].content[1].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[1].content), 4)
+        self.assertEqual( len(middle.content[0].content[1].content), 3)
         self.assertIsInstance( middle.content[0].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[0].content[1].content[0], rfc.Text):  # type-check
             return
@@ -2177,12 +2147,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 format from the diagram.
 
             """)
-        self.assertIsInstance( middle.content[0].content[1].content[3], rfc.Text) 
-        if not isinstance( middle.content[0].content[1].content[3], rfc.Text) : # type-check
-            return
-        #FIXME - unnecessary empty tag 
-        self.assertEqual( middle.content[0].content[1].content[3].content, """
-        """)
         # sec-00  content[1] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[1].anchor)
         self.assertIsNone( middle.content[0].content[1].hangText)
@@ -2279,8 +2243,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[3] <T>  Text
         self.assertIsInstance( middle.content[0].content[3].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[3].content), 2)
+        self.assertEqual( len(middle.content[0].content[3].content), 1)
         self.assertIsInstance( middle.content[0].content[3].content[0], rfc.Text)
         if not isinstance( middle.content[0].content[3].content[0], rfc.Text): # type-check 
             return
@@ -2295,12 +2258,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 retain the benefits that packet header diagrams provide, while identifying
                 the benefits of adopting a consistent format.
              """)
-        self.assertIsInstance( middle.content[0].content[3].content[1], rfc.Text) 
-        if not isinstance( middle.content[0].content[3].content[1], rfc.Text) : # type-check
-            return
-        #FIXME - unnecessary empty tag 
-        self.assertEqual( middle.content[0].content[3].content[1].content, """
-            """)
         # sec-00  content[3] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[3].anchor)
         self.assertIsNone( middle.content[0].content[3].hangText)
@@ -2313,8 +2270,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[4] <T>  Text
         self.assertIsInstance( middle.content[0].content[4].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[4].content), 2)
+        self.assertEqual( len(middle.content[0].content[4].content), 1)
         self.assertIsInstance( middle.content[0].content[4].content[0], rfc.Text)
         if not isinstance( middle.content[0].content[4].content[0], rfc.Text) : # type-check
             return
@@ -2327,12 +2283,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 writing, are described, before the format itself is given.
             """)
 
-        self.assertIsInstance( middle.content[0].content[4].content[1], rfc.Text) 
-        if not isinstance( middle.content[0].content[4].content[1], rfc.Text) : # type-check
-            return
-        #FIXME - unnecessary empty tag 
-        self.assertEqual( middle.content[0].content[4].content[1].content, """
-            """)
         # sec-00  content[4] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[4].anchor)
         self.assertIsNone( middle.content[0].content[4].hangText)
@@ -2346,8 +2296,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[5] <T>  Text
         self.assertIsInstance( middle.content[0].content[5].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[5].content), 2)
+        self.assertEqual( len(middle.content[0].content[5].content), 1)
         self.assertIsInstance( middle.content[0].content[5].content[0], rfc.Text)
         if not isinstance( middle.content[0].content[5].content[0], rfc.Text): # type-check
             return
@@ -2357,12 +2306,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 Examples that do not form part of the protocol description language are
                 marked by a colon at the beginning of each line; this prevents them from
                 being parsed by the accompanying tooling.
-            """)
-        #FIXME - unnecessary empty tag 
-        self.assertIsInstance( middle.content[0].content[5].content[1], rfc.Text) 
-        if not isinstance( middle.content[0].content[5].content[1], rfc.Text) : # type-check
-            return
-        self.assertEqual( middle.content[0].content[5].content[1].content, """
             """)
         # sec-00  content[5] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[5].anchor)
@@ -2377,8 +2320,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-00  content[6] <T>  Text
         self.assertIsInstance( middle.content[0].content[6].content, list)
-        # FIXME : unnecessary single newline - strip empty tail
-        self.assertEqual( len(middle.content[0].content[6].content), 6)
+        self.assertEqual( len(middle.content[0].content[6].content), 5)
         self.assertIsInstance( middle.content[0].content[6].content[0], rfc.Text)
         if not isinstance( middle.content[0].content[6].content[0], rfc.Text): # type-check
             return
@@ -2412,12 +2354,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual( middle.content[0].content[6].content[4].content, """) that
                 parses it (and, as described above, this document) will be provided.
             """)
-        #FIXME - unnecessary empty tag 
-        self.assertIsInstance( middle.content[0].content[6].content[5], rfc.Text) 
-        if not isinstance( middle.content[0].content[6].content[5], rfc.Text) : # type-check
-            return
-        self.assertEqual( middle.content[0].content[6].content[5].content, """
-        """)
 
         # sec-00  content[6] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[6].anchor)
@@ -2459,7 +2395,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].content[0], rfc.T) : # type-check
             return
         self.assertIsInstance( middle.content[1].content[0].content, list) 
-        self.assertEqual( len(middle.content[1].content[0].content), 2) 
+        self.assertEqual( len(middle.content[1].content[0].content), 1) 
         self.assertIsInstance( middle.content[1].content[0].content[0], rfc.Text) 
         if not isinstance( middle.content[1].content[0].content[0], rfc.Text) : # type-check
             return
@@ -2468,12 +2404,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 used in existing documents. This exposes the limitations that the current
                 usage has in terms of machine-readability, guiding the design of the
                 format that this document proposes.
-            """)
-        #FIXME :  unused newline within tag
-        self.assertIsInstance( middle.content[1].content[0].content[1], rfc.Text) 
-        if not isinstance( middle.content[1].content[0].content[1], rfc.Text) : # type-check
-            return
-        self.assertEqual( middle.content[1].content[0].content[1].content, """
             """)
         # sec-01  content[0] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].content[0].anchor)
@@ -2486,7 +2416,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].content[1], rfc.T) : # type-check
             return
         self.assertIsInstance( middle.content[1].content[1].content, list) 
-        self.assertEqual( len(middle.content[1].content[1].content), 2) 
+        self.assertEqual( len(middle.content[1].content[1].content), 1) 
         self.assertIsInstance( middle.content[1].content[1].content[0], rfc.Text) 
         if not isinstance( middle.content[1].content[1].content[0], rfc.Text) : # type-check
             return
@@ -2496,13 +2426,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 languages within IETF documents. Considering how and why these languages
                 are used provides an instructive contrast to the relatively incremental
                 approach proposed here.
-            """)
-        #FIXME :  unused newline within tag
-        self.assertIsInstance( middle.content[1].content[1].content[1], rfc.Text) 
-        if not isinstance( middle.content[1].content[1].content[1], rfc.Text) : # type-check
-            return
-        self.assertEqual( middle.content[1].content[1].content[1].content, """
-
             """)
         # sec-01  content[1] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].content[1].anchor)
@@ -2621,7 +2544,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-01  sub-sec[0] content[1] <T> content
         self.assertIsInstance( middle.content[1].sections[0].content[1].content, list)
-        self.assertEqual( len(middle.content[1].sections[0].content[1].content), 4)
+        self.assertEqual( len(middle.content[1].sections[0].content[1].content), 3)
         self.assertIsInstance( middle.content[1].sections[0].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[1].content[0], rfc.Text): # type-check
             return
@@ -2644,13 +2567,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertEqual( middle.content[1].sections[0].content[1].content[2].content, """.
                 """)
-        self.assertIsInstance( middle.content[1].sections[0].content[1].content[3], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[1].content[3], rfc.Text): # type-check
-            return
-        #FIXME : unnecessary newline 
-        self.assertEqual( middle.content[1].sections[0].content[1].content[3].content, """
-
-                """)
         # sec-01  sub-sec[0] content[2] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[1].anchor) 
         self.assertIsNone( middle.content[1].sections[0].content[1].hangText) 
@@ -2664,8 +2580,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-01  sub-sec[0] content[2] <T> content <Text>
         self.assertIsInstance( middle.content[1].sections[0].content[2].content, list)
-        #FIXME : extra newline 
-        self.assertEqual( len(middle.content[1].sections[0].content[2].content), 2)
+        self.assertEqual( len(middle.content[1].sections[0].content[2].content), 1)
         self.assertIsInstance( middle.content[1].sections[0].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[2].content[0], rfc.Text): # type-check
             return
@@ -2675,11 +2590,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   a result, while there is rough consistency in how packet header diagrams are
                   formatted, there are a number of limitations that make them difficult
                   to work with programmatically:
-                """)
-        self.assertIsInstance( middle.content[1].sections[0].content[2].content[1], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[2].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[2].content[1].content, """
                 """)
         # sec-01  sub-sec[0] content[2] <T>  anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[2].anchor) 
@@ -2717,7 +2627,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content, list)
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[0].content), 1)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[0], rfc.Text): # type-check
             return
@@ -2727,12 +2637,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                       within a diagram or document, and external consistency across
                       all documents.
                     """)
-        # FIXME : extra line item in tag <T> 
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[0].content[1].content, """
-                      """)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[0].anchor)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[0].hangText)
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[0].keepWithNext)
@@ -2744,7 +2648,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content, list)
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[1].content), 8)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[1].content), 7)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[0], rfc.Text): # type-check
             return
@@ -2803,13 +2707,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         Report Block shows the Number of Bursts field as being 12 bits wide
                         but the corresponding text describes it as 16 bits.
                       """)
-        # FIXME : extra line item in tag <T> 
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[1].content[7].content, """
-
-                      """)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].anchor)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[1].hangText)
         self.assertFalse( middle.content[1].sections[0].content[3].content[0][1].content[1].keepWithNext)
@@ -2822,7 +2719,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content, list)
         #FIXME :  class <T> additional line due to newline
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[2].content), 6)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[0][1].content[2].content), 5)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[0], rfc.Text): # type-check
             return
@@ -2856,12 +2753,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         formatted differently. If machine parsing is to be made
                         possible, then this text must be structured consistently.
                       """)
-        #FIXME :  class <T> additional line due to newline
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5], rfc.Text): #type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[0][1].content[2].content[5].content, """
-                    """)
 
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].anchor)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[0][1].content[2].hangText)
@@ -2943,8 +2834,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content, list)
-        #FIXME : <T>  remove empty tail
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[0].content), 1)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[0], rfc.Text): # type-check
             return
@@ -2956,11 +2846,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         a protocol data unit is only fully expressed if all elements can
                         be parsed.
                       """)
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[0].content[1].content, """
-                      """)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[0].anchor)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[0].hangText)
         self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[0].keepWithNext)
@@ -2970,8 +2855,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content, list)
-        #FIXME : <T>  remove empty tail
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[1].content), 4)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[2][1].content[1].content), 3)
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[0], rfc.Text): # type-check 
             return
@@ -2996,11 +2880,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         the definition of the containing structure and with the definition
                         of the sub-structure, to allow a parser to link the two together.
                       """)
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[2][1].content[1].content[3].content, """
-                    """)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].anchor)
         self.assertIsNone( middle.content[1].sections[0].content[3].content[2][1].content[1].hangText)
         self.assertFalse( middle.content[1].sections[0].content[3].content[2][1].content[1].keepWithNext)
@@ -3032,7 +2911,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content, list)
         # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content
-        self.assertEqual( len(middle.content[1].sections[0].content[3].content[3][1].content[0].content), 4)
+        self.assertEqual( len(middle.content[1].sections[0].content[3].content[3][1].content[0].content), 3)
         # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[0] <Text>
         self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[0], rfc.Text): # type-check
@@ -3061,12 +2940,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                             definition of a protocol's parsing process to be constructed
                             across multiple documents.
                         """)
-        # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> content[3] <Text>
-        self.assertIsInstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[0].content[3].content[3][1].content[0].content[3].content, """
-                    """)
         # sec-01  sub-sec[0] content[3] <DL> content[3] <tuple<DT,DD>>  [0] <DD> content[0] <T> 
         # anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[3].content[3][1].content[0].anchor)
@@ -3197,7 +3070,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # FIXME : Additional element from <T> tail content
         self.assertIsInstance( middle.content[1].sections[1].content[0].content, list)
-        self.assertEqual( len(middle.content[1].sections[1].content[0].content), 12)
+        self.assertEqual( len(middle.content[1].sections[1].content[0].content), 11)
         self.assertIsInstance( middle.content[1].sections[1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[1].sections[1].content[0].content[0], rfc.Text): # type-check 
             return
@@ -3269,12 +3142,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                     serialisation. This document specifies a structured language for specifying
                     the parsing of binary protocol data units.
                 """)
-        # FIXME : Additional element from <T> tail content[11] <Text>
-        self.assertIsInstance( middle.content[1].sections[1].content[0].content[11], rfc.Text)
-        if not isinstance( middle.content[1].sections[1].content[0].content[11], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[1].sections[1].content[0].content[11].content, """
-            """)
         # sec-01  sub-sec[1] content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[1].content[0].anchor)
         self.assertIsNone( middle.content[1].sections[1].content[0].hangText)
@@ -3321,7 +3188,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertIsInstance( middle.content[2].content[0].content, list)
         # FIXME : <T> element tail has extra space
-        self.assertEqual( len(middle.content[2].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[0].content[0], rfc.Text): # type-check
             return
@@ -3331,12 +3198,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 specifications are used and authored. To the extent that these existing uses
                 are more important than machine readability, such interference must be
                 minimised.
-            """)
-        # FIXME : <T> element tail has extra space
-        self.assertIsInstance( middle.content[2].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[0].content[1], rfc.Text):  # type-check
-            return
-        self.assertEqual( middle.content[2].content[0].content[1].content, """
             """)
         # sec-02  content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[0].anchor)
@@ -3349,8 +3210,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[1], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[1].content, list)
-        # FIXME : <T> element tail has extra space
-        self.assertEqual( len(middle.content[2].content[1].content), 2)
+        self.assertEqual( len(middle.content[2].content[1].content), 1)
         self.assertIsInstance( middle.content[2].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[1].content[0], rfc.Text): # type-check
             return
@@ -3359,12 +3219,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 described by this document are given. However, these principles apply more
                 generally to any approach that introduces structured and formal languages
                 into standards documents.
-            """)
-        # FIXME : <T> element tail has extra space
-        self.assertIsInstance( middle.content[2].content[1].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[1].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[1].content[1].content, """
             """)
         # sec-02  content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[1].anchor)
@@ -3377,8 +3231,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[2], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[2].content, list)
-        # FIXME : <T> element tail has extra space
-        self.assertEqual( len(middle.content[2].content[2].content), 2)
+        self.assertEqual( len(middle.content[2].content[2].content), 1)
         self.assertIsInstance( middle.content[2].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[2].content[0], rfc.Text):  # type-check
             return
@@ -3387,12 +3240,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 trade-offs that are inherent within any given approach. Violating these
                 principles is sometimes necessary and beneficial, and this document sets
                 out the potential consequences of doing so.
-            """)
-        # FIXME : <T> element tail has extra space
-        self.assertIsInstance( middle.content[2].content[2].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[2].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[2].content[1].content, """
             """)
         # sec-02  content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[2].anchor)
@@ -3406,8 +3253,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[3], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[3].content, list)
-        # FIXME : <T> element tail has extra space
-        self.assertEqual( len(middle.content[2].content[3].content), 2)
+        self.assertEqual( len(middle.content[2].content[3].content), 1)
         self.assertIsInstance( middle.content[2].content[3].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[3].content[0], rfc.Text): # type-check
             return
@@ -3420,12 +3266,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 approaches, as guided by the following broad design principles:
             """)
 
-        # FIXME : <T> element tail has extra space
-        self.assertIsInstance( middle.content[2].content[3].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[3].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[3].content[1].content, """
-            """)
         # sec-02  content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[3].anchor)
         self.assertIsNone( middle.content[2].content[3].hangText)
@@ -3465,8 +3305,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[0][1].content[0], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[0][1].content[0].content[0], rfc.Text): # type-check
             return
@@ -3476,12 +3315,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         cannot be easily parsed by people should be avoided, and if
                         included, should be clearly delineated from human-readable
                         content.
-                    """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[0][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[0][1].content[0].content[1].content, """
                     """)
         # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[0][1].content[0].anchor)
@@ -3494,8 +3327,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[0][1].content[1], rfc.T): # type-check
             return
         self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[1].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[0][1].content[1].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[0][1].content[1].content[0], rfc.Text): # type-check
             return
@@ -3505,12 +3337,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         standardisation process, which relies upon discussion centered
                         around documents written in prose.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[0][1].content[1].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[0][1].content[1].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[0][1].content[1].content[1].content, """
-                """)
         # sec-02 content[4] <DL> content[0] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[0][1].content[1].anchor)
         self.assertIsNone( middle.content[2].content[4].content[0][1].content[1].hangText)
@@ -3542,8 +3368,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[1][1].content[0], rfc.T):  # type-check
              return
         self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[1][1].content[0].content[0], rfc.Text):  # type-check
              return
@@ -3556,12 +3381,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         development of optional, supplementary tools that aid in the
                         authoring machine-readable structures.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[1][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[1][1].content[0].content[1].content, """
-                    """)
         # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[1][1].content[0].anchor)
         self.assertIsNone( middle.content[2].content[4].content[1][1].content[0].hangText)
@@ -3573,8 +3392,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[1][1].content[1], rfc.T):  # type-check
             return
         self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[1].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[1][1].content[1].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[1][1].content[1].content[0], rfc.Text): # type-check
             return
@@ -3584,12 +3402,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         authors whose workflows are incompatible might be alienated from
                         the process.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[1][1].content[1].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[1][1].content[1].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[1][1].content[1].content[1].content, """
-                """)
         # sec-02 content[4] <DL> content[1] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[1][1].content[1].anchor)
         self.assertIsNone( middle.content[2].content[4].content[1][1].content[1].hangText)
@@ -3623,8 +3435,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content, list)
         if not isinstance( middle.content[2].content[4].content[2][1].content[0].content, list): # type-check
             return
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[2][1].content[0].content[0], rfc.Text): # type-check
              return
@@ -3637,12 +3448,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         human readable text, is undesirable because it creates
                         the potential for inconsistency.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[2][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[2][1].content[0].content[1].content, """
-                    """)
         # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[2][1].content[0].anchor)
         self.assertIsNone( middle.content[2].content[4].content[2][1].content[0].hangText)
@@ -3653,8 +3458,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[2][1].content[1], rfc.T): # return
             return
         self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[1].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[2][1].content[1].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[2][1].content[1].content[0], rfc.Text): #type-check
              return
@@ -3667,12 +3471,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         introducing the potential for the program code to specify behaviour
                         that the prose-based specification does not, and vice-versa.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[2][1].content[1].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[2][1].content[1].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[2][1].content[1].content[1].content, """
-                """)
         # sec-02 content[4] <DL> content[2] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[2][1].content[1].anchor)
         self.assertIsNone( middle.content[2].content[4].content[2][1].content[1].hangText)
@@ -3701,8 +3499,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( middle.content[2].content[4].content[2][1].content[0], rfc.T)
         if not isinstance( middle.content[2].content[4].content[3][1].content[0], rfc.T): #type-check
             return
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[3][1].content[0].content[0], rfc.Text): # type-check
             return
@@ -3719,11 +3516,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         cases might be preferred to a complex tool that addresses all
                         use cases.
                     """)
-        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[3][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[3][1].content[0].content[1].content, """
-                    """)
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[0].anchor)
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[0].hangText)
         self.assertFalse( middle.content[2].content[4].content[3][1].content[0].keepWithNext)
@@ -3732,8 +3524,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1], rfc.T)
         if not isinstance( middle.content[2].content[4].content[3][1].content[1], rfc.T): # type-check
              return
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[1].content), 4)
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[1].content), 3)
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[0], rfc.Text): 
              return
@@ -3762,12 +3553,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         expressiveness of the protocol description languages that they use to
                         define their protocols can force such awareness.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[1].content[3], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[3][1].content[1].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[3][1].content[1].content[3].content, """
-                    """)
         # sec-02 content[4] <DL> content[3] <Tuple<DT,DL> [1] <DD> content [1] <T> anchor, handText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].anchor)
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[1].hangText)
@@ -3777,8 +3562,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2], rfc.T)
         if not isinstance( middle.content[2].content[4].content[3][1].content[2], rfc.T): # type-check
             return
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[2].content), 4)
+        self.assertEqual( len(middle.content[2].content[4].content[3][1].content[2].content), 3)
         self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[0], rfc.Text): # type-check
             return
@@ -3803,11 +3587,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[2].content, """.
                     """)
-        self.assertIsInstance( middle.content[2].content[4].content[3][1].content[2].content[3], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[3][1].content[2].content[3], rfc.Text):  # type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[3][1].content[2].content[3].content, """
-                """)
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].anchor)
         self.assertIsNone( middle.content[2].content[4].content[3][1].content[2].hangText)
         self.assertFalse( middle.content[2].content[4].content[3][1].content[2].keepWithNext)
@@ -3838,8 +3617,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[2].content[4].content[4][1].content[0], rfc.T):  # type-check
             return
         self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content, list)
-        # FIXME : <T>  extra line in tail 
-        self.assertEqual( len(middle.content[2].content[4].content[4][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[2].content[4].content[4][1].content[0].content), 1)
         self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[2].content[4].content[4][1].content[0].content[0], rfc.Text): # type-check
             return
@@ -3850,12 +3628,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                         the IETF's standardisation process: there are very few components
                         of standards documents that are non-optional.
                     """)
-        # FIXME : <T>  extra line in tail 
-        self.assertIsInstance( middle.content[2].content[4].content[4][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[2].content[4].content[4][1].content[0].content[1], rfc.Text):  #  type-check
-            return
-        self.assertEqual( middle.content[2].content[4].content[4][1].content[0].content[1].content, """
-                """)
         self.assertIsNone( middle.content[2].content[4].content[4][1].content[0].anchor)
         self.assertIsNone( middle.content[2].content[4].content[4][1].content[0].hangText)
         self.assertFalse( middle.content[2].content[4].content[4][1].content[0].keepWithNext)
@@ -3902,8 +3674,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 content[0] <T> content
         self.assertIsInstance( middle.content[3].content[0].content, list) 
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].content[0].content), 4) 
+        self.assertEqual( len(middle.content[3].content[0].content), 3) 
         self.assertIsInstance( middle.content[3].content[0].content[0], rfc.Text )
         if not isinstance( middle.content[3].content[0].content[0], rfc.Text ): # type-check
             return
@@ -3927,12 +3698,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 can express most binary protocol features, and require no changes to
                 existing publication processes.
             """)
-        self.assertIsInstance( middle.content[3].content[0].content[3], rfc.Text )
-        if not isinstance( middle.content[3].content[0].content[3], rfc.Text ): # type-check
-            return
-        # FIXME : <T> extra line in tail
-        self.assertEqual( middle.content[3].content[0].content[3].content, """
-            """)
         # sec-03 content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].content[0].anchor) 
         self.assertIsNone( middle.content[3].content[0].hangText)
@@ -3945,8 +3710,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 content[1] <T> content
         self.assertIsInstance( middle.content[3].content[1].content, list) 
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].content[1].content), 4) 
+        self.assertEqual( len(middle.content[3].content[1].content), 3) 
         self.assertIsInstance( middle.content[3].content[1].content[0], rfc.Text )
         if not isinstance( middle.content[3].content[1].content[0], rfc.Text ): # type-check
             return
@@ -3968,27 +3732,19 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                 are to be parsed by machine. In this section, an augmented packet
                 header diagram format is described.
             """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].content[1].content[3], rfc.Text )
-        if not isinstance( middle.content[3].content[1].content[3], rfc.Text ): #  type-check
-            return
-        self.assertEqual( middle.content[3].content[1].content[3].content, """
-            """)
         # sec-03 content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].content[1].anchor) 
         self.assertIsNone( middle.content[3].content[1].hangText)
         self.assertFalse( middle.content[3].content[1].keepWithNext)
         self.assertFalse( middle.content[3].content[1].keepWithPrevious)
 
-###### FROM HERE 
         # sec-03 content[2] <T>
         self.assertIsInstance( middle.content[3].content[2], rfc.T) 
         if not isinstance( middle.content[3].content[2], rfc.T) : # type-check
             return
         # sec-03 content[2] <T> content
         self.assertIsInstance( middle.content[3].content[2].content, list) 
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].content[2].content), 4) 
+        self.assertEqual( len(middle.content[3].content[2].content), 3) 
         self.assertIsInstance( middle.content[3].content[2].content[0], rfc.Text )
         if not isinstance( middle.content[3].content[2].content[0], rfc.Text ):
             return
@@ -4008,13 +3764,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         if not isinstance( middle.content[3].content[2].content[2], rfc.Text ):
             return
         self.assertEqual( middle.content[3].content[2].content[2].content, """.
-            """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].content[2].content[3], rfc.Text )
-        if not isinstance( middle.content[3].content[2].content[3], rfc.Text ):
-            return
-        self.assertEqual( middle.content[3].content[2].content[3].content, """
-
             """)
         # sec-03 content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].content[2].anchor) 
@@ -4047,8 +3796,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [0] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[0].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[0].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[0].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[0].content[0], rfc.Text):
             return
@@ -4056,13 +3804,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   The simplest PDU is one that contains only a set of fixed-width
                   fields in a known order, with no optional fields or variation
                   in the packet format.
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[0].content[1], rfc.Text):
-             return
-        self.assertEqual( middle.content[3].sections[0].content[0].content[1].content, """
-
                 """)
         # sec-03 sub-sec[0] content [0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[0].anchor) 
@@ -4077,7 +3818,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # sec-03 sub-sec[0] content [1] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[1].content, list)
         # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[1].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[1].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[1].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[1].content[0], rfc.Text): #type-check
             return
@@ -4087,13 +3828,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   some previous field, or is unspecified and inferred from
                   the total size of the packet and the size of the other
                   fields.
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[1].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[1].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[3].sections[0].content[1].content[1].content, """
-
                 """)
         # sec-03 sub-sec[0] content [1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[1].anchor) 
@@ -4107,8 +3841,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [2] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[2].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[2].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[2].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[2].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[2].content[0], rfc.Text): # type-check
             return
@@ -4118,13 +3851,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   The length of a single field, where all other fields are
                   of known (but perhaps variable) length, can be inferred
                   from the total size of the containing PDU.
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[2].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[2].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[3].sections[0].content[2].content[1].content, """
-
                 """)
         # sec-03 sub-sec[0] content [2] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[2].anchor) 
@@ -4138,8 +3864,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [3] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[3].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[3].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[3].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[3].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[3].content[0], rfc.Text): #  type-check
             return
@@ -4151,13 +3876,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   starting with a header line to show the bit width of the diagram.
                   The description of the fields follows the diagram, as an XML
                   <dl> list, after a paragraph containing the text "where:".
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[3].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[3].content[1], rfc.Text):  # type-check
-             return
-        self.assertEqual( middle.content[3].sections[0].content[3].content[1].content, """
-
                 """)
         # sec-03 sub-sec[0] content [3] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[3].anchor) 
@@ -4171,8 +3889,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [4] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[4].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[4].content), 4)
+        self.assertEqual( len(middle.content[3].sections[0].content[4].content), 3)
         self.assertIsInstance( middle.content[3].sections[0].content[4].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[4].content[0], rfc.Text): # type-check
             return
@@ -4193,13 +3910,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         self.assertEqual( middle.content[3].sections[0].content[4].content[2].content, """).
                 """)
-        self.assertIsInstance( middle.content[3].sections[0].content[4].content[3], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[4].content[3], rfc.Text): # type-check
-            return
-        # FIXME : <T> extra line in tail
-        self.assertEqual( middle.content[3].sections[0].content[4].content[3].content, """
-
-                """)
         # sec-03 sub-sec[0] content [4] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[4].anchor) 
         self.assertIsNone( middle.content[3].sections[0].content[4].hangText)
@@ -4214,8 +3924,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [5] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[5].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[5].content), 4)
+        self.assertEqual( len(middle.content[3].sections[0].content[5].content), 3)
         self.assertIsInstance( middle.content[3].sections[0].content[5].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[5].content[0], rfc.Text): # type-check
             return
@@ -4241,13 +3950,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                   cannot be the same as a previously defined PDU name, and must
                   be unique within a given structure definition.
                 """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[5].content[3], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[5].content[3], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[3].sections[0].content[5].content[3].content, """
-
-                """)
         # sec-03 sub-sec[0] content [5] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[5].anchor) 
         self.assertIsNone( middle.content[3].sections[0].content[5].hangText)
@@ -4260,8 +3962,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [6] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[6].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[6].content), 4)
+        self.assertEqual( len(middle.content[3].sections[0].content[6].content), 3)
         self.assertIsInstance( middle.content[3].sections[0].content[6].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[6].content[0], rfc.Text) : # type-check
             return
@@ -4281,12 +3982,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertEqual( middle.content[3].sections[0].content[6].content[2].content,
                 """. An IPv4 Header is formatted
                  as follows:
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[6].content[3], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[6].content[3], rfc.Text): # type-check
-             return
-        self.assertEqual( middle.content[3].sections[0].content[6].content[3].content, """
                 """)
         # sec-03 sub-sec[0] content [6] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[6].anchor) 
@@ -4340,19 +4035,12 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [8] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[8].content, list)
-        # FIXME : <T> extra line in tail
-        self.assertEqual( len(middle.content[3].sections[0].content[8].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[8].content), 1)
         self.assertIsInstance( middle.content[3].sections[0].content[8].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[8].content[0], rfc.Text): # type-check
             return
         self.assertEqual( middle.content[3].sections[0].content[8].content[0].content, """
                     where:
-                """)
-        # FIXME : <T> extra line in tail
-        self.assertIsInstance( middle.content[3].sections[0].content[8].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[8].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[3].sections[0].content[8].content[1].content, """
                 """)
         # sec-03 sub-sec[0] content [8] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[8].anchor) 
@@ -4390,8 +4078,7 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
             return
         # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content
         self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content, list)
-        #FIXME : <T> tail-element
-        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content[0].content), 2)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content[0].content), 1)
         # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content[0]
         self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[0], rfc.Text)
         if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[0], rfc.Text): # type-check
@@ -4402,13 +4089,6 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
                             in the label of the description list, separated from the
                             field's label by a colon.
                         """)
-        #FIXME : <T> tail-element
-        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content[1]
-        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1], rfc.Text): # type-check
-            return
-        self.assertEqual( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1].content, """
-                    """)
         # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].content[0].anchor)
         self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].content[0].hangText)

--- a/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_xml_draft_mcquistin_augmented_ascii_diagrams.py
@@ -4367,23 +4367,462 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         # sec-03 sub-sec[0] content [9] <DL> content 
         self.assertIsInstance( middle.content[3].sections[0].content[9].content, list)
         self.assertEqual( len(middle.content[3].sections[0].content[9].content), 15)
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
-        # DJ section-03 subsection[0] content[9] DL --- continue 
+
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][0].content[0].content, """
+                        Version (V): 4 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0], rfc.T)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0], rfc.T): # type-check
+            return
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content, list)
+        #FIXME : <T> tail-element
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content[0].content), 2)
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content[0]
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][1].content[0].content[0].content, """
+                            This is a fixed-width field, whose full label is shown
+                            in the diagram. The field's width -- 4 bits -- is given
+                            in the label of the description list, separated from the
+                            field's label by a colon.
+                        """)
+        #FIXME : <T> tail-element
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> content[1]
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][1].content[0].content[1].content, """
+                    """)
+        # sec-03 sub-sec[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].content[0].anchor)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].content[0].hangText)
+        self.assertFalse( middle.content[3].sections[0].content[9].content[0][1].content[0].keepWithNext)
+        self.assertFalse( middle.content[3].sections[0].content[9].content[0][1].content[0].keepWithPrevious)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].anchor)
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [1] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [1] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[1][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[1][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[1][0].content[0].content, """
+                        Internet Header Length (IHL): 4 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[1][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [1] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[1][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[1][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[1][1].content[0].content, """
+                        This is a shorter field, whose full label is too large to be
+                        shown in the diagram. A short label (IHL) is used in the diagram, and this
+                        short label is provided, in brackets, after the full label
+                        in the description list.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[1][1].anchor)
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [2] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [2] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[2][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[2][0].content[0], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[2][0].content[0].content, """
+                        Differentiated Services Code Point (DSCP): 6 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[2][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [2] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[2][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[2][1].content[0], rfc.Text): # typecheck
+             return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[2][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[2][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [3] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [3] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[3][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[3][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[3][0].content[0].content, """
+                        Explicit Congestion Notification (ECN): 2 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[3][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [3] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[3][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[3][1].content[0], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[3][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[3][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [4] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [4] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[4][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[4][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[4][0].content[0].content, """
+                        Total Length (TL): 2 bytes.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[4][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [4] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[4][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[4][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[4][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed. Where
+                        fields are an integral number of bytes in size, the field
+                        length can be given in bytes rather than in bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[4][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [5] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [5] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[5][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[5][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[5][0].content[0].content, """
+                        Identification: 2 bytes.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[5][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [5] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[5][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[5][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[5][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[5][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [6] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [6] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[6][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[6][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[6][0].content[0].content, """
+                        Flags: 3 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[6][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [6] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[6][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[6][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[6][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[6][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [7] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [7] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[7][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[7][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[7][0].content[0].content, """
+                        Fragment Offset: 13 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[7][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [7] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[7][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[7][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[7][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[7][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [8] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [8] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[8][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[8][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[8][0].content[0].content, """
+                        Time to Live (TTL): 1 byte.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[8][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [8] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[8][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[8][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[8][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[8][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [9] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [9] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[9][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[9][0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[9][0].content[0].content, """
+                        Protocol: 1 byte.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[9][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [9] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[9][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[9][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[9][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[9][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [10] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [10] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[10][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[10][0].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[10][0].content[0].content, """
+                        Header Checksum: 2 bytes.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[10][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [10] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[10][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[10][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[10][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[10][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [11] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [11] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[11][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[11][0].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[11][0].content[0].content, """
+                        Source Address: 32 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[11][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [11] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[11][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[11][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[11][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[11][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [12] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [12] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[12][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[12][0].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[12][0].content[0].content, """
+                        Destination Address: 32 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[12][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [12] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[12][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[12][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[12][1].content[0].content, """
+                        This is a fixed-width field, as previously discussed.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[12][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [13] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [13] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[13][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][0].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][0].content[0].content, """
+                        Options: (IHL-5)*32 bits.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [13] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[13][1].content), 3)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[0].content, """
+                      This is a variable-length field, whose length is defined
+                      by the value of the field with short label IHL (Internet
+                      Header Length).  Constraint expressions can be used in place of
+                      constant values: the grammar for the expression language is
+                      defined in """)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content[1], rfc.XRef)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][1].content[1], rfc.XRef):# type-check
+            return
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].content[1].content)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].content[1].format)
+        self.assertFalse( middle.content[3].sections[0].content[9].content[13][1].content[1].pageno)
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[1].target, """ABNF-constraints""")
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content[2], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][1].content[2], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[2].content,
+                    """. Constraints can
+                      include a previously defined field's short or full label, where one has been
+                      defined. Short variable-length fields are indicated by "..."
+                      instead of a pipe at the end of the row.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].anchor)
+
+
+
+        # sec-03 sub-sec[0] content [9] <DL> content [14] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14], tuple)
+        # sec-03 sub-sec[0] content [9] <DL> content [14] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[14][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[14][0].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[14][0].content[0].content, """
+                        Payload: TL - ((IHL*32)/8) bytes.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[14][0].anchor)
+        # sec-03 sub-sec[0] content [9] <DL> content [12] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[14][1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[14][1].content[0], rfc.Text):# type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[14][1].content[0].content, """
+                      This is a multi-row variable-length field, constrained by
+                      the values of fields TL and IHL.  Instead of the "..." notation,
+                      ":" is used to indicate that the field is variable-length.
+                      The use of ":" instead of "..." indicates the field is likely
+                      to be a longer, multi-row field.  However, semantically, there
+                      is no difference: these different notations are for the benefit
+                      of human readers.
+                    """)
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[14][1].anchor)
+
+
         # sec-03 sub-sec[0] content [9] <DL> anchor, hanging, spacing
         self.assertIsNone( middle.content[3].sections[0].content[9].anchor)
         self.assertTrue( middle.content[3].sections[0].content[9].hanging) 
@@ -4401,8 +4840,20 @@ class Test_Parse_XML_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase)
         self.assertIsNone(middle.content[3].sections[0].title)
         self.assertEqual(middle.content[3].sections[0].toc, "default")
 
+#.......................................
+#....... TO BE CONTINUED................
+#.......................................
+
         # sec-03 sub-sec[1] 
         self.assertIsInstance( middle.content[3].sections[1], rfc.Section)
+        # sec-03  sub-sec[1] anchor, numbered removeInRFC, title,  toc
+        self.assertEqual(middle.content[3].sections[1].anchor, "ascii-xref")
+        self.assertTrue(middle.content[3].sections[1].numbered)
+        self.assertFalse(middle.content[3].sections[1].removeInRFC)
+        self.assertIsNone(middle.content[3].sections[1].title)
+        self.assertEqual(middle.content[3].sections[1].toc, "default")
+
+
         # sec-03 sub-sec[2] 
         self.assertIsInstance( middle.content[3].sections[2], rfc.Section)
         # sec-03 sub-sec[3] 


### PR DESCRIPTION
Fix bugs for 
1) <T>  parsing and adding empty tail element as additional text 
2) tocDepth  defaults to "3"  rfcv3 7991  2.45.14
3) stream attribute in streamInfo defaults to "IETF" -- rfcv3 7991 2.47.5
4) xref format attribute in streamInfo defaults to "default" -- rfcv3 2.66.1

Unit tests reflecting these changes will be submitted in a separate pull request