### PR TITLE
change text document parser file and include within installer

### DIFF
--- a/npt/parser_rfc_txt.py
+++ b/npt/parser_rfc_txt.py
@@ -97,7 +97,7 @@ def generate_parser(grammarFilename):
 def parse_rfc(rfcTxt):
     rfcTxt = depaginate(rfcTxt)
     rfcTxt = trim_blank_lines(rfcTxt)
-    parser = generate_parser("rfc-grammar.txt")
+    parser = generate_parser("npt/grammar_rfc.txt")
     rfc = parser("".join(rfcTxt)).rfc()
     return rfc
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/glasgow-ipl/ips-protodesc-code",
     packages = ['npt'],
     package_data = {
-        'npt': ['py.typed'],
+        'npt': ['py.typed', 'grammar_rfc.txt' ],
     },
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
1. text parser failing due to incorrect parsley file being opened. 
2. Add text file as artifact to add within installation process