### PR TITLE
Post processing - for review only

### DIFF
--- a/npt/grammar_rfc.txt
+++ b/npt/grammar_rfc.txt
@@ -40,7 +40,7 @@ ascii_packet_diag_ref = nl
 ascii_packet_diagram = ascii_packet_header:header 
                        line+:lines 
                        ascii_packet_diag_ref?:fig_ref
-                        -> rfc.Artwork( [rfc.Text("".join([header] + lines))], 
+                        -> rfc.Artwork( rfc.Text("".join([header] + lines)), 
                                         "left",
                                         None,
                                         fig_ref[0] if fig_ref else None,

--- a/npt/grammar_rfc.txt
+++ b/npt/grammar_rfc.txt
@@ -15,7 +15,8 @@ ws = ' '*
 nl = '\n'
 
 line = tab ws <((word|number) ws)+>:txt nl:newline -> txt+newline
-t = line+:lines -> rfc.T([rfc.Text("".join(lines))], None, None, None, None)
+paragraph_line = <tab ws>:indentation <((word|number) ws)+>:txt nl:newline -> indentation+txt+newline
+t = paragraph_line+:lines -> rfc.T([rfc.Text("".join(lines))], None, None, None, None)
 tocline = tab ws <(letter '.')?>:alpha <(number '.')*>:num ws (word ws)+ number? nl -> infer_toc(alpha, num)
 section_name = <(number '.')+>:number ws <(word ws)+>:name nl -> (number.count('.'), name)
 appendix_name = "Appendix " (letter '.') ws <(word ws)+>:name nl -> (1, name)

--- a/npt/parser_rfc_postprocess.py
+++ b/npt/parser_rfc_postprocess.py
@@ -1,0 +1,211 @@
+# =================================================================================================
+# Copyright (C) 2018-2020 University of Glasgow
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# =================================================================================================
+
+#import abc
+#from typing       import Dict, List, Tuple, Optional, Any, Union
+#from npt.protocol import Protocol
+
+from typing       import Dict
+import npt.rfc as rfc
+import npt.protocol
+import npt.parser_asciidiagrams as ascii_parser
+
+
+def iter_child(node): 
+    if getattr(node, "__annotations__", None) == None : 
+        return 
+
+    for field in  node.__annotations__ : 
+        try : 
+            yield field, getattr(node, field) 
+        except AttributeError : 
+            pass
+
+
+class NodeVisitor:
+    def isiterable(self, node):
+        try : 
+            k = iter(node)
+        except TypeError as expt :
+            return False 
+        else : 
+            return True
+
+    def visit(self, node):
+        method = "visit_" + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        #print(f"calling  {method} ---> {visitor}")
+        return visitor(node) 
+
+    def generic_visit(self, node):
+        for name, field in iter_child( node ):
+            #print(f"key [{name}]  -> field {type(field)}")
+            if field is None :   # check if optional 
+                #print(f"1. ####### key {name}  is Optional\n") 
+                pass
+            elif self.isiterable(field): # check if iterable 
+                #print(f"2. ####### key {name}  is iterable\n") 
+                for item in field :
+                    #print(f">>>>>>>>> key {name} visiting {type(item)} \n") 
+                    self.visit(item)
+            else : # check object type which needs to be recursed 
+                #print(f"3. ####### key {name}  is {type(field)} \n") 
+                self.visit(field)
+
+class TraverseRFC(NodeVisitor):
+    def __init__(self, root, symbols):
+        self.root = root 
+        self.sym = symbols
+
+        asciiParser = ascii_parser.AsciiDiagramsParser()
+        asciiParser.proto = npt.protocol.Protocol()
+        self.parser = asciiParser.build_parser()
+
+    def visit_RFC(self, node ):
+        self.generic_visit(node)
+
+    def visit_Middle(self, node):
+        self.generic_visit(node)
+
+    def visit_Section(self,node):
+        self.generic_visit(node)
+        xform_dl: List[Tuple[int,rfc.DL]] = [] 
+
+        flag = False
+        for pdu_grp in reversed(self._group_pdu(node)):
+            self._convert_to_pdu(node, pdu_grp)
+            flag = True
+
+        if flag : 
+            print(f"\n\n-----------AFTER CONVERSION BEGIN :--------------") 
+            for idx,child in enumerate(node.content): 
+                if not isinstance(child,rfc.DL): 
+                    print(f"[{idx}] ******\n{child}") 
+                else: 
+                    for i,dl in enumerate(child.content):
+                        print(f"  [{idx}.{i}] -> dt = {dl[0]}") 
+                        print(f"  [{idx}.{i}] -> dd = {dl[1]}") 
+            print(f"-----------AFTER CONVERSION END :-------------\n\n")
+
+    def _group_pdu(self, section):
+        start = anchor = None
+        rawPDU = [] # start-idx, end-idx+1 , art-work node
+
+        for idx, child in enumerate(section.content): 
+            if isinstance(child, rfc.Artwork):
+                if anchor != None : # more than one artwork 
+                    rawPDU.append((start, idx, anchor))
+                start, anchor = (idx, child)
+        else :
+            if anchor != None : 
+                rawPDU.append((start, idx+1, anchor))
+        return rawPDU
+
+
+    def _convert_to_pdu(self, section, action):
+        start, end, artWork = action
+        # assert guard conditions 
+        if not isinstance(section.content[start], rfc.Artwork) \
+           or not isinstance(section.content[start].content, rfc.Text):
+            return
+        artwork = section.content[start].content.content
+
+        if start == (end-1) \
+           or not isinstance(section.content[start+1], rfc.T) \
+           or len(section.content[start+1].content) != 1 : 
+            return 
+
+        where = section.content[start+1].content[0].content.strip().split() 
+        if len(where) != 1 or where[0] != "where:" :
+            return
+
+        # Parse out all field names
+        try: 
+            artwork_fields = self.parser(artwork.strip()).diagram() 
+            #print(f"Diagram ->\n{artwork}\n-----------------\nArt Fields -> {artwork_fields}")
+        except Exception as e:
+            return
+
+        # verify  number of field descriptions match list of fields
+        if (end - start) < (len(artwork_fields) + 2):
+            #print(f"ASSERT--ASSERT --> ({end}-{start}) < {len(artwork_fields)}+2")
+            return
+
+        # parse each <t> element and convert to (<dt>, <dd>) pairs
+        field_desc, consumed = [], 0
+        try: 
+            for elem_t in section.content[start+2:end]:
+                if len(field_desc) == len(artwork_fields): 
+                    break 
+
+                # check paragraph description is a <t> element
+                if not isinstance(elem_t, rfc.T) \
+                   or len(elem_t.content) != 1 \
+                   or not isinstance(elem_t.content[0], rfc.Text):
+                    raise Exception(f"Expected rfc.T element. Found {type(elem_t)} -->  {elem_t}")
+
+                text = elem_t.content[0].content
+                try : 
+                    delim = text.index(". ")
+                except ValueError as vexcpt: 
+                    delim = text.index(".")
+
+                # check if current <t> section is a new field description or 
+                if (len(text) - len(text.lstrip())) == len( self.sym['tab']): 
+                    field_desc.append( (rfc.DT([rfc.Text( text[:delim+1])], None), 
+                                        rfc.DD([rfc.Text( text[delim+1:])], None)) ) 
+                elif len(field_desc) > 0 :
+                    if isinstance(field_desc[-1][1].content[0], rfc.Text): 
+                        # convert to list of <t> elements
+                        field_desc[-1][1].content[0] = rfc.T( [field_desc[-1][1].content[0]], None, None, False, False)
+                        #assert False, f"1. Are we here yet? text = {text}\n<T> = {field_desc[-1][1].content[0]}\n</T>\ntype = {type(field_desc[-1][1].content[0])}"
+                    # generate <t> element and append to previous PDU desc <dd> 
+                    field_desc[-1][1].content.append( rfc.T( [rfc.Text(text)], None, None, False, False))
+                else :
+                    raise Exception(f"Formatting error in PDU description."
+                                    f"Field name description does not start with correct indentation. Text = \n"
+                                    f"{text}")
+                consumed+=1
+        except Exception as e:
+            #print(f"\n\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n{e}")
+            #print(f"<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n")
+            return
+
+        section.content.insert(start+2, rfc.DL( field_desc, None , True , "normal")) 
+        section.content = section.content[:start+3] + section.content[start+3+consumed:]
+        return
+
+
+# Convert relevant <t> elements to <dl> 
+def text_to_dl( root_node: rfc , symbols: Dict[str,str]) -> rfc : 
+    postProcess = TraverseRFC(root_node.middle, symbols )
+    postProcess.visit(root_node.middle)
+    #assert False, "We are here"
+    return root_node 

--- a/npt/parser_rfc_txt.py
+++ b/npt/parser_rfc_txt.py
@@ -33,6 +33,7 @@ import parsley
 import string
 
 import npt.rfc as rfc
+import npt.parser_rfc_postprocess as domProcess
 
 from typing import Dict, List
 
@@ -103,6 +104,7 @@ def parse_rfc(rfcTxt):
     rfcTxt = trim_blank_lines(rfcTxt)
     parser = generate_parser("npt/grammar_rfc.txt")
     rfc = parser("".join(rfcTxt)).rfc()
+    rfc = domProcess.text_to_dl(rfc, {'tab': ''.join( parser('   ').tab())})
     return rfc
 
 if __name__ == "__main__":

--- a/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
@@ -3609,14 +3609,10 @@ diagram.
         self.assertIsInstance( middle.content[0].content[2], rfc.Artwork)
         if not isinstance( middle.content[0].content[2], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[0].content[2].content, list)
-        if not isinstance( middle.content[0].content[2].content, list):
+        self.assertIsInstance( middle.content[0].content[2].content, rfc.Text)
+        if not isinstance( middle.content[0].content[2].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[0].content[2].content), 1)
-        self.assertIsInstance( middle.content[0].content[2].content[0], rfc.Text)
-        if not isinstance( middle.content[0].content[2].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[0].content[2].content[0].content,
+        self.assertEqual( middle.content[0].content[2].content.content,
 """:    0                   1                   2                   3
 :    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 :   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -3863,14 +3859,10 @@ to the relatively incremental approach proposed here.
         self.assertIsInstance( middle.content[1].sections[0].content[0], rfc.Artwork)
         if not isinstance( middle.content[1].sections[0].content[0], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[1].sections[0].content[0].content, list)
-        if not isinstance( middle.content[1].sections[0].content[0].content, list):
+        self.assertIsInstance( middle.content[1].sections[0].content[0].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[0].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[1].sections[0].content[0].content), 1)
-        self.assertIsInstance( middle.content[1].sections[0].content[0].content[0], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[0].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[1].sections[0].content[0].content[0].content,
+        self.assertEqual( middle.content[1].sections[0].content[0].content.content,
 """:   The RESET_STREAM frame is as follows:
 :
 :    0                   1                   2                   3
@@ -4167,14 +4159,10 @@ constructed across multiple documents.
         self.assertIsInstance(middle.content[1].sections[0].content[12], rfc.Artwork)
         if not isinstance(middle.content[1].sections[0].content[12], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[1].sections[0].content[12].content, list)
-        if not isinstance( middle.content[1].sections[0].content[12].content, list):
+        self.assertIsInstance( middle.content[1].sections[0].content[12].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[12].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[1].sections[0].content[12].content), 1)
-        self.assertIsInstance( middle.content[1].sections[0].content[12].content[0], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[12].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[1].sections[0].content[12].content[0].content,
+        self.assertEqual( middle.content[1].sections[0].content[12].content.content,
 """:   The format of the "Relay Source Port Option" is shown below:
 :
 :    0                   1                   2                   3
@@ -4366,14 +4354,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[0].content[7], rfc.Artwork)
         if not isinstance(middle.content[3].sections[0].content[7], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[0].content[7].content, list)
-        if not isinstance(middle.content[3].sections[0].content[7].content, list):
+        self.assertIsInstance( middle.content[3].sections[0].content[7].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[7].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[0].content[7].content), 1)
-        self.assertIsInstance( middle.content[3].sections[0].content[7].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[7].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[0].content[7].content[0].content, 
+        self.assertEqual( middle.content[3].sections[0].content[7].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4463,14 +4447,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[1].content[1], rfc.Artwork)
         if not isinstance(middle.content[3].sections[1].content[1], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[1].content[1].content, list)
-        if not isinstance(middle.content[3].sections[1].content[1].content, list):
+        self.assertIsInstance( middle.content[3].sections[1].content[1].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[1].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[1].content[1].content), 1)
-        self.assertIsInstance( middle.content[3].sections[1].content[1].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[1].content[1].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[1].content[1].content[0].content, 
+        self.assertEqual( middle.content[3].sections[1].content[1].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4505,14 +4485,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[1].content[6], rfc.Artwork)
         if not isinstance(middle.content[3].sections[1].content[6], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[1].content[6].content, list)
-        if not isinstance(middle.content[3].sections[1].content[6].content, list):
+        self.assertIsInstance( middle.content[3].sections[1].content[6].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[6].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[1].content[6].content), 1)
-        self.assertIsInstance( middle.content[3].sections[1].content[6].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[1].content[6].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[1].content[6].content[0].content, 
+        self.assertEqual( middle.content[3].sections[1].content[6].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4594,14 +4570,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[2].content[2], rfc.Artwork)
         if not isinstance(middle.content[3].sections[2].content[2], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[2].content[2].content, list)
-        if not isinstance(middle.content[3].sections[2].content[2].content, list):
+        self.assertIsInstance( middle.content[3].sections[2].content[2].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[2].content[2].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[2].content[2].content), 1)
-        self.assertIsInstance( middle.content[3].sections[2].content[2].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[2].content[2].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[2].content[2].content[0].content, 
+        self.assertEqual( middle.content[3].sections[2].content[2].content.content, 
 """0                   1
 0 1 2 3 4 5 6 7 8 9 0 1 2 3
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+


### PR DESCRIPTION
1. Postprocessing on RFC text files. 
2. Initial parsing will only differentiate between <artwork> and <t> elements. 
3. Recursive DOM walker used to identify and transform every <section> element. 
4. Postprocessing phase will convert PDU  field descriptions into <dl> lists; 
    to make it as similar to the xml processing pipeline as possible. 
