### PR TITLE
Postprocessing PDU diagrams for RFC text files

### DIFF
--- a/npt/grammar_asciidiagrams.txt
+++ b/npt/grammar_asciidiagrams.txt
@@ -14,7 +14,8 @@ number           = <digit+>:ds -> int(ds)
 
 capitalised_word = uppercase_letter:l <(lowercase_letter|punc)*>:ls -> str(l + ls)
 
-pdu_name = <(alphanum:w ?(w != "is" and w != "protocol" and w != "PDUs" and w != "and" and w != "or" and w != "using")' '?)>*:name -> stem("".join(name).strip())
+pdu_part = <(alphanum:w ?(w not in ["is", "protocol", "PDUs", "and", "or", "using"]))>:name -> name
+pdu_name = <(pdu_part ws)*>:name -> stem("".join(name).strip())
 
 # expressions redo
 parens = '(' ws equality_expr:e ws ')' -> e
@@ -107,6 +108,5 @@ serialised_to_func = <(word:w ?(w != "An" and w != "A")' '?)+>? ("An "|"A ") pdu
 parsed_from_func = <(word:w ?(w != "An" and w != "A")' '?)+>? ("An "|"A ") pdu_name:to_type "is parsed from " ("an " | "a ") pdu_name:from_type 'using the ' short_field_name:func_name  ' function.' anything* -> (from_type, to_type, func_name)
 
 # Protocol Definition
-
-pdu_list = pdu_name:name (', ' ('and ')? pdu_name:names)*:names -> [name] + names
-protocol_definition = <(word:w ?(w != 'The' and w != "This")' '?)+>? 'This' ws 'document' ws 'describes' ws 'the' ws pdu_name:p_name 'protocol.' ws 'The' ws pdu_name:name ws 'protocol' ws 'uses' ws pdu_list:names '.' -> (name, names)
+pdu_list = pdu_name:name (',' ws ('and ')? pdu_name:names)*:names -> [name] + names
+protocol_definition = <(word:w ?(w != 'The' and w != "This") ws)+>? 'This' ws 'document' ws 'describes' ws 'the' ws pdu_name:p_name_1 ws 'protocol.' ws 'The' ws pdu_name:p_name_2 ws 'protocol' ws 'uses' ws pdu_list:names '.' -> (p_name_1, names)

--- a/npt/grammar_rfc.txt
+++ b/npt/grammar_rfc.txt
@@ -40,7 +40,7 @@ ascii_packet_diag_ref = nl
 ascii_packet_diagram = ascii_packet_header:header 
                        line+:lines 
                        ascii_packet_diag_ref?:fig_ref
-                        -> rfc.Artwork( [rfc.Text("".join([header] + lines))], 
+                        -> rfc.Artwork( rfc.Text("".join([header] + lines)), 
                                         "left",
                                         None,
                                         fig_ref[0] if fig_ref else None,

--- a/npt/grammar_rfc.txt
+++ b/npt/grammar_rfc.txt
@@ -15,7 +15,8 @@ ws = ' '*
 nl = '\n'
 
 line = tab ws <((word|number) ws)+>:txt nl:newline -> txt+newline
-t = line+:lines -> rfc.T([rfc.Text("".join(lines))], None, None, None, None)
+paragraph_line = <tab ws>:indentation <((word|number) ws)+>:txt nl:newline -> indentation+txt+newline
+t = paragraph_line+:lines -> rfc.T([rfc.Text("".join(lines))], None, None, None, None)
 tocline = tab ws <(letter '.')?>:alpha <(number '.')*>:num ws (word ws)+ number? nl -> infer_toc(alpha, num)
 section_name = <(number '.')+>:number ws <(word ws)+>:name nl -> (number.count('.'), name)
 appendix_name = "Appendix " (letter '.') ws <(word ws)+>:name nl -> (1, name)

--- a/npt/parser_asciidiagrams.py
+++ b/npt/parser_asciidiagrams.py
@@ -52,6 +52,7 @@ def valid_field_name_convertor(name):
 def valid_type_name_convertor(name):
     if name[0].isdigit():
         name = "T" + name
+    name = ' '.join(name.replace('\n',' ').split())
     return name.capitalize().replace(" ", "_")
 
 class AsciiDiagramsParser(Parser):

--- a/npt/parser_rfc_postprocess.py
+++ b/npt/parser_rfc_postprocess.py
@@ -1,0 +1,211 @@
+# =================================================================================================
+# Copyright (C) 2018-2020 University of Glasgow
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# =================================================================================================
+
+#import abc
+#from typing       import Dict, List, Tuple, Optional, Any, Union
+#from npt.protocol import Protocol
+
+from typing       import Dict
+import npt.rfc as rfc
+import npt.protocol
+import npt.parser_asciidiagrams as ascii_parser
+
+
+def iter_child(node): 
+    if getattr(node, "__annotations__", None) == None : 
+        return 
+
+    for field in  node.__annotations__ : 
+        try : 
+            yield field, getattr(node, field) 
+        except AttributeError : 
+            pass
+
+
+class NodeVisitor:
+    def isiterable(self, node):
+        try : 
+            k = iter(node)
+        except TypeError as expt :
+            return False 
+        else : 
+            return True
+
+    def visit(self, node):
+        method = "visit_" + node.__class__.__name__
+        visitor = getattr(self, method, self.generic_visit)
+        #print(f"calling  {method} ---> {visitor}")
+        return visitor(node) 
+
+    def generic_visit(self, node):
+        for name, field in iter_child( node ):
+            #print(f"key [{name}]  -> field {type(field)}")
+            if field is None :   # check if optional 
+                #print(f"1. ####### key {name}  is Optional\n") 
+                pass
+            elif self.isiterable(field): # check if iterable 
+                #print(f"2. ####### key {name}  is iterable\n") 
+                for item in field :
+                    #print(f">>>>>>>>> key {name} visiting {type(item)} \n") 
+                    self.visit(item)
+            else : # check object type which needs to be recursed 
+                #print(f"3. ####### key {name}  is {type(field)} \n") 
+                self.visit(field)
+
+class TraverseRFC(NodeVisitor):
+    def __init__(self, root, symbols):
+        self.root = root 
+        self.sym = symbols
+
+        asciiParser = ascii_parser.AsciiDiagramsParser()
+        asciiParser.proto = npt.protocol.Protocol()
+        self.parser = asciiParser.build_parser()
+
+    def visit_RFC(self, node ):
+        self.generic_visit(node)
+
+    def visit_Middle(self, node):
+        self.generic_visit(node)
+
+    def visit_Section(self,node):
+        self.generic_visit(node)
+        xform_dl: List[Tuple[int,rfc.DL]] = [] 
+
+        flag = False
+        for pdu_grp in reversed(self._group_pdu(node)):
+            self._convert_to_pdu(node, pdu_grp)
+            flag = True
+
+        if flag : 
+            print(f"\n\n-----------AFTER CONVERSION BEGIN :--------------") 
+            for idx,child in enumerate(node.content): 
+                if not isinstance(child,rfc.DL): 
+                    print(f"[{idx}] ******\n{child}") 
+                else: 
+                    for i,dl in enumerate(child.content):
+                        print(f"  [{idx}.{i}] -> dt = {dl[0]}") 
+                        print(f"  [{idx}.{i}] -> dd = {dl[1]}") 
+            print(f"-----------AFTER CONVERSION END :-------------\n\n")
+
+    def _group_pdu(self, section):
+        start = anchor = None
+        rawPDU = [] # start-idx, end-idx+1 , art-work node
+
+        for idx, child in enumerate(section.content): 
+            if isinstance(child, rfc.Artwork):
+                if anchor != None : # more than one artwork 
+                    rawPDU.append((start, idx, anchor))
+                start, anchor = (idx, child)
+        else :
+            if anchor != None : 
+                rawPDU.append((start, idx+1, anchor))
+        return rawPDU
+
+
+    def _convert_to_pdu(self, section, action):
+        start, end, artWork = action
+        # assert guard conditions 
+        if not isinstance(section.content[start], rfc.Artwork) \
+           or not isinstance(section.content[start].content, rfc.Text):
+            return
+        artwork = section.content[start].content.content
+
+        if start == (end-1) \
+           or not isinstance(section.content[start+1], rfc.T) \
+           or len(section.content[start+1].content) != 1 : 
+            return 
+
+        where = section.content[start+1].content[0].content.strip().split() 
+        if len(where) != 1 or where[0] != "where:" :
+            return
+
+        # Parse out all field names
+        try: 
+            artwork_fields = self.parser(artwork.strip()).diagram() 
+            #print(f"Diagram ->\n{artwork}\n-----------------\nArt Fields -> {artwork_fields}")
+        except Exception as e:
+            return
+
+        # verify  number of field descriptions match list of fields
+        if (end - start) < (len(artwork_fields) + 2):
+            #print(f"ASSERT--ASSERT --> ({end}-{start}) < {len(artwork_fields)}+2")
+            return
+
+        # parse each <t> element and convert to (<dt>, <dd>) pairs
+        field_desc, consumed = [], 0
+        try: 
+            for elem_t in section.content[start+2:end]:
+                if len(field_desc) == len(artwork_fields): 
+                    break 
+
+                # check paragraph description is a <t> element
+                if not isinstance(elem_t, rfc.T) \
+                   or len(elem_t.content) != 1 \
+                   or not isinstance(elem_t.content[0], rfc.Text):
+                    raise Exception(f"Expected rfc.T element. Found {type(elem_t)} -->  {elem_t}")
+
+                text = elem_t.content[0].content
+                try : 
+                    delim = text.index(". ")
+                except ValueError as vexcpt: 
+                    delim = text.index(".")
+
+                # check if current <t> section is a new field description or 
+                if (len(text) - len(text.lstrip())) == len( self.sym['tab']): 
+                    field_desc.append( (rfc.DT([rfc.Text( text[:delim+1])], None), 
+                                        rfc.DD([rfc.Text( text[delim+1:])], None)) ) 
+                elif len(field_desc) > 0 :
+                    if isinstance(field_desc[-1][1].content[0], rfc.Text): 
+                        # convert to list of <t> elements
+                        field_desc[-1][1].content[0] = rfc.T( [field_desc[-1][1].content[0]], None, None, False, False)
+                        #assert False, f"1. Are we here yet? text = {text}\n<T> = {field_desc[-1][1].content[0]}\n</T>\ntype = {type(field_desc[-1][1].content[0])}"
+                    # generate <t> element and append to previous PDU desc <dd> 
+                    field_desc[-1][1].content.append( rfc.T( [rfc.Text(text)], None, None, False, False))
+                else :
+                    raise Exception(f"Formatting error in PDU description."
+                                    f"Field name description does not start with correct indentation. Text = \n"
+                                    f"{text}")
+                consumed+=1
+        except Exception as e:
+            #print(f"\n\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n{e}")
+            #print(f"<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n<><><><><><><><><>\n")
+            return
+
+        section.content.insert(start+2, rfc.DL( field_desc, None , True , "normal")) 
+        section.content = section.content[:start+3] + section.content[start+3+consumed:]
+        return
+
+
+# Convert relevant <t> elements to <dl> 
+def text_to_dl( root_node: rfc , symbols: Dict[str,str]) -> rfc : 
+    postProcess = TraverseRFC(root_node.middle, symbols )
+    postProcess.visit(root_node.middle)
+    #assert False, "We are here"
+    return root_node 

--- a/npt/parser_rfc_txt.py
+++ b/npt/parser_rfc_txt.py
@@ -33,6 +33,7 @@ import parsley
 import string
 
 import npt.rfc as rfc
+import npt.parser_rfc_postprocess as domProcess
 
 from typing import Dict, List
 
@@ -103,6 +104,7 @@ def parse_rfc(rfcTxt):
     rfcTxt = trim_blank_lines(rfcTxt)
     parser = generate_parser("npt/grammar_rfc.txt")
     rfc = parser("".join(rfcTxt)).rfc()
+    rfc = domProcess.text_to_dl(rfc, {'tab': ''.join( parser('   ').tab())})
     return rfc
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/glasgow-ipl/ips-protodesc-code",
     packages = ['npt'],
     package_data = {
-        'npt': ['py.typed', 'grammar_rfc.txt' ],
+        'npt': ['py.typed', 'grammar_rfc.txt' , 'grammar_asciidiagrams.txt'],
     },
     entry_points = {
         'console_scripts': [

--- a/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
@@ -48,50 +48,50 @@ from typing import Union, Optional, List, Tuple
 
 
 class Test_Parse_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase):
-#    def test_xml_rfc_root(self) :
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-#            raw_content = fd.read()
-#            xml_tree = ET.fromstring(raw_content)
-#            node = npt.parser_rfc_xml.parse_rfc(xml_tree)
-#            self._verify_rfc_dom_root(node, True)
-#
-#    def test_xml_rfc_front(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-#            raw_content = fd.read()
-#            xml_tree = ET.fromstring(raw_content)
-#            node = npt.parser_rfc_xml.parse_rfc(xml_tree).front
-#            self._verify_rfc_dom_front(node)
-#
-#    def test_xml_rfc_middle(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-#            raw_content = fd.read()
-#            xml_tree = ET.fromstring(raw_content)
-#            middle = npt.parser_rfc_xml.parse_rfc(xml_tree).middle
-#            self._verify_rfc_middle(middle)
-#
-#
-#    def test_xml_rfc_back(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-#            raw_content = fd.read()
-#            xml_tree = ET.fromstring(raw_content)
-#            back = npt.parser_rfc_xml.parse_rfc(xml_tree).back 
-#            if back is not None : 
-#                self._verify_rfc_dom_back(back)
-#
-#    def test_txt_rfc_root(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-#            content = fd.readlines()
-#            root = npt.parser_rfc_txt.parse_rfc(content)
-#            self.assertIsInstance(root, rfc.RFC)
-#            self._verify_rfc_dom_root(root, False)
-#
-#
-#    def test_txt_rfc_front(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-#            content = fd.readlines()
-#            root = npt.parser_rfc_txt.parse_rfc(content)
-#            self.assertIsInstance(root, rfc.RFC)
-#            self._verify_rfc_txt_dom_front(root.front)
+    def test_xml_rfc_root(self) :
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+            raw_content = fd.read()
+            xml_tree = ET.fromstring(raw_content)
+            node = npt.parser_rfc_xml.parse_rfc(xml_tree)
+            self._verify_rfc_dom_root(node, True)
+
+    def test_xml_rfc_front(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+            raw_content = fd.read()
+            xml_tree = ET.fromstring(raw_content)
+            node = npt.parser_rfc_xml.parse_rfc(xml_tree).front
+            self._verify_rfc_dom_front(node)
+
+    def test_xml_rfc_middle(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+            raw_content = fd.read()
+            xml_tree = ET.fromstring(raw_content)
+            middle = npt.parser_rfc_xml.parse_rfc(xml_tree).middle
+            self._verify_rfc_middle(middle)
+
+
+    def test_xml_rfc_back(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+            raw_content = fd.read()
+            xml_tree = ET.fromstring(raw_content)
+            back = npt.parser_rfc_xml.parse_rfc(xml_tree).back 
+            if back is not None : 
+                self._verify_rfc_dom_back(back)
+
+    def test_txt_rfc_root(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+            content = fd.readlines()
+            root = npt.parser_rfc_txt.parse_rfc(content)
+            self.assertIsInstance(root, rfc.RFC)
+            self._verify_rfc_dom_root(root, False)
+
+
+    def test_txt_rfc_front(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+            content = fd.readlines()
+            root = npt.parser_rfc_txt.parse_rfc(content)
+            self.assertIsInstance(root, rfc.RFC)
+            self._verify_rfc_txt_dom_front(root.front)
 
     def test_txt_rfc_middle(self):
         with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
@@ -100,12 +100,12 @@ class Test_Parse_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase):
             self.assertIsInstance(root, rfc.RFC)
             self._verify_rfc_txt_dom_middle(root.middle)
 
-#    def test_txt_rfc_back(self):
-#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-#            content = fd.readlines()
-#            root = npt.parser_rfc_txt.parse_rfc(content)
-#            self.assertIsInstance(root, rfc.RFC)
-#            self._verify_rfc_txt_dom_back(root.back)
+    def test_txt_rfc_back(self):
+        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+            content = fd.readlines()
+            root = npt.parser_rfc_txt.parse_rfc(content)
+            self.assertIsInstance(root, rfc.RFC)
+            self._verify_rfc_txt_dom_back(root.back)
 
     def _verify_rfc_dom_root(self, root: rfc.RFC, xml_doc: bool) :
         self.assertIsInstance( root.links, list)

--- a/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
@@ -48,50 +48,50 @@ from typing import Union, Optional, List, Tuple
 
 
 class Test_Parse_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase):
-    def test_xml_rfc_root(self) :
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-            raw_content = fd.read()
-            xml_tree = ET.fromstring(raw_content)
-            node = npt.parser_rfc_xml.parse_rfc(xml_tree)
-            self._verify_rfc_dom_root(node, True)
-
-    def test_xml_rfc_front(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-            raw_content = fd.read()
-            xml_tree = ET.fromstring(raw_content)
-            node = npt.parser_rfc_xml.parse_rfc(xml_tree).front
-            self._verify_rfc_dom_front(node)
-
-    def test_xml_rfc_middle(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-            raw_content = fd.read()
-            xml_tree = ET.fromstring(raw_content)
-            middle = npt.parser_rfc_xml.parse_rfc(xml_tree).middle
-            self._verify_rfc_middle(middle)
-
-
-    def test_xml_rfc_back(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
-            raw_content = fd.read()
-            xml_tree = ET.fromstring(raw_content)
-            back = npt.parser_rfc_xml.parse_rfc(xml_tree).back 
-            if back is not None : 
-                self._verify_rfc_dom_back(back)
-
-    def test_txt_rfc_root(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-            content = fd.readlines()
-            root = npt.parser_rfc_txt.parse_rfc(content)
-            self.assertIsInstance(root, rfc.RFC)
-            self._verify_rfc_dom_root(root, False)
-
-
-    def test_txt_rfc_front(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-            content = fd.readlines()
-            root = npt.parser_rfc_txt.parse_rfc(content)
-            self.assertIsInstance(root, rfc.RFC)
-            self._verify_rfc_txt_dom_front(root.front)
+#    def test_xml_rfc_root(self) :
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+#            raw_content = fd.read()
+#            xml_tree = ET.fromstring(raw_content)
+#            node = npt.parser_rfc_xml.parse_rfc(xml_tree)
+#            self._verify_rfc_dom_root(node, True)
+#
+#    def test_xml_rfc_front(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+#            raw_content = fd.read()
+#            xml_tree = ET.fromstring(raw_content)
+#            node = npt.parser_rfc_xml.parse_rfc(xml_tree).front
+#            self._verify_rfc_dom_front(node)
+#
+#    def test_xml_rfc_middle(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+#            raw_content = fd.read()
+#            xml_tree = ET.fromstring(raw_content)
+#            middle = npt.parser_rfc_xml.parse_rfc(xml_tree).middle
+#            self._verify_rfc_middle(middle)
+#
+#
+#    def test_xml_rfc_back(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.xml" , 'r') as fd:
+#            raw_content = fd.read()
+#            xml_tree = ET.fromstring(raw_content)
+#            back = npt.parser_rfc_xml.parse_rfc(xml_tree).back 
+#            if back is not None : 
+#                self._verify_rfc_dom_back(back)
+#
+#    def test_txt_rfc_root(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+#            content = fd.readlines()
+#            root = npt.parser_rfc_txt.parse_rfc(content)
+#            self.assertIsInstance(root, rfc.RFC)
+#            self._verify_rfc_dom_root(root, False)
+#
+#
+#    def test_txt_rfc_front(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+#            content = fd.readlines()
+#            root = npt.parser_rfc_txt.parse_rfc(content)
+#            self.assertIsInstance(root, rfc.RFC)
+#            self._verify_rfc_txt_dom_front(root.front)
 
     def test_txt_rfc_middle(self):
         with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
@@ -100,12 +100,12 @@ class Test_Parse_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase):
             self.assertIsInstance(root, rfc.RFC)
             self._verify_rfc_txt_dom_middle(root.middle)
 
-    def test_txt_rfc_back(self):
-        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
-            content = fd.readlines()
-            root = npt.parser_rfc_txt.parse_rfc(content)
-            self.assertIsInstance(root, rfc.RFC)
-            self._verify_rfc_txt_dom_back(root.back)
+#    def test_txt_rfc_back(self):
+#        with open("examples/draft-mcquistin-augmented-ascii-diagrams.txt" , 'r') as fd:
+#            content = fd.readlines()
+#            root = npt.parser_rfc_txt.parse_rfc(content)
+#            self.assertIsInstance(root, rfc.RFC)
+#            self._verify_rfc_txt_dom_back(root.back)
 
     def _verify_rfc_dom_root(self, root: rfc.RFC, xml_doc: bool) :
         self.assertIsInstance( root.links, list)
@@ -206,13 +206,13 @@ class Test_Parse_Draft_McQuistin_Augmented_Ascii_Diagrams(unittest.TestCase):
         self.assertIsInstance( front.abstract.content[0].content[0].content , str)
         self.maxDiff = None 
         self.assertEqual     ( front.abstract.content[0].content[0].content,
-"""This document describes a machine-readable format for specifying the
-syntax of protocol data units within a protocol specification.  This
-format is comprised of a consistently formatted packet header
-diagram, followed by structured explanatory text.  It is designed to
-maintain human readability while enabling support for automated
-parser generation from the specification document.  This document is
-itself an example of how the format can be used.
+"""   This document describes a machine-readable format for specifying the
+   syntax of protocol data units within a protocol specification.  This
+   format is comprised of a consistently formatted packet header
+   diagram, followed by structured explanatory text.  It is designed to
+   maintain human readability while enabling support for automated
+   parser generation from the specification document.  This document is
+   itself an example of how the format can be used.
 """)
 
 
@@ -754,11 +754,12 @@ itself an example of how the format can be used.
         if not isinstance(back.sections[0].sections[0].content[0].content[0], rfc.Text): # type check
             return
         self.assertEqual(back.sections[0].sections[0].content[0].content[0].content,
-"""cond-expr = eq-expr "?" cond-expr ":" eq-expr
-eq-expr   = bool-expr eq-op   bool-expr
-bool-expr = ord-expr  bool-op ord-expr
-ord-expr  = add-expr  ord-op  add-expr
+"""       cond-expr = eq-expr "?" cond-expr ":" eq-expr
+       eq-expr   = bool-expr eq-op   bool-expr
+       bool-expr = ord-expr  bool-op ord-expr
+       ord-expr  = add-expr  ord-op  add-expr
 """)
+
         # section-00 -- (sub) section 00 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[0].sections[0].content[0].anchor)
         self.assertIsNone( back.sections[0].sections[0].content[0].hangText)
@@ -775,12 +776,13 @@ ord-expr  = add-expr  ord-op  add-expr
         if not isinstance(back.sections[0].sections[0].content[1].content[0], rfc.Text): # type-check 
             return
         self.assertEqual(back.sections[0].sections[0].content[1].content[0].content,
-"""add-expr  = mul-expr  add-op  mul-expr
-mul-expr  = pow-expr  mul-op  pow-expr
-pow-expr  = expr      pow-op  expr
-expr      = *DIGIT / field-name /
-field-name-ws / "(" expr ")"
+"""       add-expr  = mul-expr  add-op  mul-expr
+       mul-expr  = pow-expr  mul-op  pow-expr
+       pow-expr  = expr      pow-op  expr
+       expr      = *DIGIT / field-name /
+                   field-name-ws / "(" expr ")"
 """)
+
         # section-00 -- (sub) section 00 -- content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[0].sections[0].content[1].anchor)
         self.assertIsNone( back.sections[0].sections[0].content[1].hangText)
@@ -797,8 +799,8 @@ field-name-ws / "(" expr ")"
         if not isinstance(back.sections[0].sections[0].content[2].content[0], rfc.Text): # type-check
             return
         self.assertEqual(back.sections[0].sections[0].content[2].content[0].content,
-"""field-name    = ALPHA *(ALPHA / DIGIT)
-field-name-ws = *(field-name " ")
+"""       field-name    = ALPHA *(ALPHA / DIGIT)
+       field-name-ws = *(field-name " ")
 """)
         # section-00 -- (sub) section 00 -- content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[0].sections[0].content[2].anchor)
@@ -816,12 +818,12 @@ field-name-ws = *(field-name " ")
         if not isinstance(back.sections[0].sections[0].content[3].content[0], rfc.Text): # type-check
             return
         self.assertEqual(back.sections[0].sections[0].content[3].content[0].content,
-"""pow-op  = "^"
-mul-op  = "*" / "/" / "%"
-add-op  = "+" / "-"
-ord-op  = "<=" / "<" / ">=" / ">"
-bool-op = "&&" / "||" / "!"
-eq-op   = "==" / "!="
+"""       pow-op  = "^"
+       mul-op  = "*" / "/" / "%"
+       add-op  = "+" / "-"
+       ord-op  = "<=" / "<" / ">=" / ">"
+       bool-op = "&&" / "||" / "!"
+       eq-op   = "==" / "!="
 """)
 
         # section-00 -- (sub) section 00 -- content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
@@ -867,12 +869,12 @@ eq-op   = "==" / "!="
         if not isinstance(back.sections[0].sections[1].content[0].content[0], rfc.Text): # type-check 
             return
         self.assertEqual(back.sections[0].sections[1].content[0].content[0].content,
-"""Future revisions of this draft will include an ABNF specification for
-the augmented packet diagram format described in Section 4.  Such a
-specification is omitted from this draft given that the format is
-likely to change as its syntax is developed.  Given the visual nature
-of the format, it is more appropriate for discussion to focus on the
-examples given in Section 4.
+"""   Future revisions of this draft will include an ABNF specification for
+   the augmented packet diagram format described in Section 4.  Such a
+   specification is omitted from this draft given that the format is
+   likely to change as its syntax is developed.  Given the visual nature
+   of the format, it is more appropriate for discussion to focus on the
+   examples given in Section 4.
 """)
         # section-00 -- (sub) section 01 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[0].sections[1].content[0].anchor)
@@ -923,8 +925,8 @@ examples given in Section 4.
         if not isinstance(back.sections[1].content[0].content[0], rfc.Text):  # type-check
              return
         self.assertEqual(back.sections[1].content[0].content[0].content,
-"""The source for this draft is available from https://github.com/
-glasgow-ipl/draft-mcquistin-augmented-ascii-diagrams.
+"""   The source for this draft is available from https://github.com/
+   glasgow-ipl/draft-mcquistin-augmented-ascii-diagrams.
 """)
         # section-01 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[1].content[0].anchor)
@@ -942,8 +944,8 @@ glasgow-ipl/draft-mcquistin-augmented-ascii-diagrams.
         if not isinstance(back.sections[1].content[1].content[0], rfc.Text): # type-check
             return
         self.assertEqual(back.sections[1].content[1].content[0].content,
-"""The source code for tooling that can be used to parse this document
-is available from https://github.com/glasgow-ipl/ips-protodesc-code.
+"""   The source code for tooling that can be used to parse this document
+   is available from https://github.com/glasgow-ipl/ips-protodesc-code.
 """)
         # section-00 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( back.sections[1].content[1].anchor)
@@ -3568,11 +3570,11 @@ is available from https://github.com/glasgow-ipl/ips-protodesc-code.
         if not isinstance(middle.content[0].content[0].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[0].content[0].content,
-"""Packet header diagrams have become a widely used format for
-describing the syntax of binary protocols.  In otherwise largely
-textual documents, they allow for the visualisation of packet
-formats, reducing human error, and aiding in the implementation of
-parsers for the protocols that they specify.
+"""   Packet header diagrams have become a widely used format for
+   describing the syntax of binary protocols.  In otherwise largely
+   textual documents, they allow for the visualisation of packet
+   formats, reducing human error, and aiding in the implementation of
+   parsers for the protocols that they specify.
 """)
         # section-00 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[0].anchor)
@@ -3591,13 +3593,13 @@ parsers for the protocols that they specify.
         if not isinstance(middle.content[0].content[1].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[1].content[0].content,
-"""Figure 1 gives an example of how packet header diagrams are used to
-define binary protocol formats.  The format has an obvious structure:
-the diagram clearly delineates each field, showing its width and its
-position within the header.  This type of diagram is designed for
-human readers, but is consistent enough that it should be possible to
-develop a tool that generates a parser for the packet format from the
-diagram.
+"""   Figure 1 gives an example of how packet header diagrams are used to
+   define binary protocol formats.  The format has an obvious structure:
+   the diagram clearly delineates each field, showing its width and its
+   position within the header.  This type of diagram is designed for
+   human readers, but is consistent enough that it should be possible to
+   develop a tool that generates a parser for the packet format from the
+   diagram.
 """)
         # section-00 -- content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[1].anchor)
@@ -3656,14 +3658,14 @@ diagram.
         if not isinstance(middle.content[0].content[3].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[3].content[0].content,
-"""Unfortunately, the format of such packet diagrams varies both within
-and between documents.  This variation makes it difficult to build
-tools to generate parsers from the specifications.  Better tooling
-could be developed if protocol specifications adopted a consistent
-format for their packet descriptions.  Indeed, this underpins the
-format described by this draft: we want to retain the benefits that
-packet header diagrams provide, while identifying the benefits of
-adopting a consistent format.
+"""   Unfortunately, the format of such packet diagrams varies both within
+   and between documents.  This variation makes it difficult to build
+   tools to generate parsers from the specifications.  Better tooling
+   could be developed if protocol specifications adopted a consistent
+   format for their packet descriptions.  Indeed, this underpins the
+   format described by this draft: we want to retain the benefits that
+   packet header diagrams provide, while identifying the benefits of
+   adopting a consistent format.
 """)
         # section-00 -- content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[3].anchor)
@@ -3682,13 +3684,13 @@ adopting a consistent format.
         if not isinstance(middle.content[0].content[4].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[4].content[0].content,
-"""This document describes a consistent packet header diagram format and
-accompanying structured text constructs that allow for the parsing
-process of protocol headers to be fully specified.  This provides
-support for the automatic generation of parser code.  Broad design
-principles, that seek to maintain the primacy of human readability
-and flexibility in writing, are described, before the format itself
-is given.
+"""   This document describes a consistent packet header diagram format and
+   accompanying structured text constructs that allow for the parsing
+   process of protocol headers to be fully specified.  This provides
+   support for the automatic generation of parser code.  Broad design
+   principles, that seek to maintain the primacy of human readability
+   and flexibility in writing, are described, before the format itself
+   is given.
 """)
         # section-00 -- content[4] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[4].anchor)
@@ -3707,12 +3709,12 @@ is given.
         if not isinstance(middle.content[0].content[5].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[5].content[0].content,
-"""This document is itself an example of the approach that it describes,
-with the packet header diagrams and structured text format described
-by example.  Examples that do not form part of the protocol
-description language are marked by a colon at the beginning of each
-line; this prevents them from being parsed by the accompanying
-tooling.
+"""   This document is itself an example of the approach that it describes,
+   with the packet header diagrams and structured text format described
+   by example.  Examples that do not form part of the protocol
+   description language are marked by a colon at the beginning of each
+   line; this prevents them from being parsed by the accompanying
+   tooling.
 """)
         # section-00 -- content[5] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[5].anchor)
@@ -3731,8 +3733,8 @@ tooling.
         if not isinstance(middle.content[0].content[6].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[6].content[0].content,
-"""This draft describes early work.  As consensus builds around the
-particular syntax of the format described, both a formal ABNF
+"""   This draft describes early work.  As consensus builds around the
+   particular syntax of the format described, both a formal ABNF
 """)
         # section-00 -- content[6] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[6].anchor)
@@ -3751,8 +3753,8 @@ particular syntax of the format described, both a formal ABNF
         if not isinstance(middle.content[0].content[7].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[0].content[7].content[0].content,
-"""specification (Appendix A) and code (Appendix B) that parses it (and,
-as described above, this document) will be provided.
+"""   specification (Appendix A) and code (Appendix B) that parses it (and,
+   as described above, this document) will be provided.
 """)
         # section-00 -- content[7] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[0].content[7].anchor)
@@ -3798,10 +3800,10 @@ as described above, this document) will be provided.
         if not isinstance(middle.content[1].content[0].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].content[0].content[0].content,
-"""This section begins by considering how packet header diagrams are
-used in existing documents.  This exposes the limitations that the
-current usage has in terms of machine-readability, guiding the design
-of the format that this document proposes.
+"""   This section begins by considering how packet header diagrams are
+   used in existing documents.  This exposes the limitations that the
+   current usage has in terms of machine-readability, guiding the design
+   of the format that this document proposes.
 """)
         # section-01 -- content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].content[0].anchor)
@@ -3821,11 +3823,11 @@ of the format that this document proposes.
         if not isinstance(middle.content[1].content[1].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].content[1].content[0].content,
-"""While this document focuses on the machine-readability of packet
-format diagrams, this section also discusses the use of other
-structured or formal languages within IETF documents.  Considering
-how and why these languages are used provides an instructive contrast
-to the relatively incremental approach proposed here.
+"""   While this document focuses on the machine-readability of packet
+   format diagrams, this section also discusses the use of other
+   structured or formal languages within IETF documents.  Considering
+   how and why these languages are used provides an instructive contrast
+   to the relatively incremental approach proposed here.
 """)
         # section-01 -- content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].content[1].anchor)
@@ -3910,10 +3912,10 @@ to the relatively incremental approach proposed here.
         if not isinstance(middle.content[1].sections[0].content[1].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[1].content[0].content,
-"""Packet header diagrams are frequently used in IETF standards to
-describe the format of binary protocols.  While there is no standard
-for how these diagrams should be formatted, they have a broadly
-similar structure, where the layout of a protocol data unit (PDU) or
+"""   Packet header diagrams are frequently used in IETF standards to
+   describe the format of binary protocols.  While there is no standard
+   for how these diagrams should be formatted, they have a broadly
+   similar structure, where the layout of a protocol data unit (PDU) or
 """)
         # section-01 -- subsection[0] content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[1].anchor)
@@ -3931,9 +3933,9 @@ similar structure, where the layout of a protocol data unit (PDU) or
         if not isinstance(middle.content[1].sections[0].content[2].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[2].content[0].content,
-"""structure is shown in diagrammatic form, followed by a description
-list of the fields that it contains.  An example of this format,
-taken from the QUIC specification, is given in Figure 2.
+"""   structure is shown in diagrammatic form, followed by a description
+   list of the fields that it contains.  An example of this format,
+   taken from the QUIC specification, is given in Figure 2.
 """)
         # section-01 -- subsection[0] content[2] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[2].anchor)
@@ -3951,11 +3953,11 @@ taken from the QUIC specification, is given in Figure 2.
         if not isinstance(middle.content[1].sections[0].content[3].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[3].content[0].content,
-"""These packet header diagrams, and the accompanying descriptions, are
-formatted for human readers rather than for automated processing.  As
-a result, while there is rough consistency in how packet header
-diagrams are formatted, there are a number of limitations that make
-them difficult to work with programmatically:
+"""   These packet header diagrams, and the accompanying descriptions, are
+   formatted for human readers rather than for automated processing.  As
+   a result, while there is rough consistency in how packet header
+   diagrams are formatted, there are a number of limitations that make
+   them difficult to work with programmatically:
 """)
         # section-01 -- subsection[0] content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[3].anchor)
@@ -3973,10 +3975,10 @@ them difficult to work with programmatically:
         if not isinstance(middle.content[1].sections[0].content[4].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[4].content[0].content,
-"""Inconsistent syntax:  There are two classes of consistency that are
-needed to support automated processing of specifications: internal
-consistency within a diagram or document, and external consistency
-across all documents.
+"""   Inconsistent syntax:  There are two classes of consistency that are
+      needed to support automated processing of specifications: internal
+      consistency within a diagram or document, and external consistency
+      across all documents.
 """)
         # section-01 -- subsection[0] content[3] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[4].anchor)
@@ -3995,20 +3997,20 @@ across all documents.
         if not isinstance(middle.content[1].sections[0].content[5].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[5].content[0].content,
-"""Figure 2 gives an example of internal inconsistency.  Here, the
-packet diagram shows a field labelled "Application Error Code",
-while the accompanying description lists the field as "Application
-Protocol Error Code".  The use of an abbreviated name is suitable
-for human readers, but makes parsing the structure difficult for
-machines.  Figure 3 gives a further example, where the description
-includes an "Option-Code" field that does not appear in the packet
-diagram; and where the description states that each field is 16
-bits in length, but the diagram shows the OPTION_RELAY_PORT as 13
-bits, and Option-Len as 19 bits.  Another example is [RFC6958],
-where the packet format diagram showing the structure of the
-Burst/Gap Loss Metrics Report Block shows the Number of Bursts
-field as being 12 bits wide but the corresponding text describes
-it as 16 bits.
+"""      Figure 2 gives an example of internal inconsistency.  Here, the
+      packet diagram shows a field labelled "Application Error Code",
+      while the accompanying description lists the field as "Application
+      Protocol Error Code".  The use of an abbreviated name is suitable
+      for human readers, but makes parsing the structure difficult for
+      machines.  Figure 3 gives a further example, where the description
+      includes an "Option-Code" field that does not appear in the packet
+      diagram; and where the description states that each field is 16
+      bits in length, but the diagram shows the OPTION_RELAY_PORT as 13
+      bits, and Option-Len as 19 bits.  Another example is [RFC6958],
+      where the packet format diagram showing the structure of the
+      Burst/Gap Loss Metrics Report Block shows the Number of Bursts
+      field as being 12 bits wide but the corresponding text describes
+      it as 16 bits.
 """)
         # section-01 -- subsection[0] content[5] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[5].anchor)
@@ -4026,11 +4028,11 @@ it as 16 bits.
         if not isinstance(middle.content[1].sections[0].content[6].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[6].content[0].content,
-"""Comparing Figure 2 with Figure 3 exposes external inconsistency
-across documents.  While the packet format diagrams are broadly
-similar, the surrounding text is formatted differently.  If
-machine parsing is to be made possible, then this text must be
-structured consistently.
+"""      Comparing Figure 2 with Figure 3 exposes external inconsistency
+      across documents.  While the packet format diagrams are broadly
+      similar, the surrounding text is formatted differently.  If
+      machine parsing is to be made possible, then this text must be
+      structured consistently.
 """)
         # section-01 -- subsection[0] content[6] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[6].anchor)
@@ -4049,15 +4051,15 @@ structured consistently.
         if not isinstance(middle.content[1].sections[0].content[7].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[7].content[0].content,
-"""Ambiguous constraints:  The constraints that are enforced on a
-particular field are often described ambiguously, or in a way that
-cannot be parsed easily.  In Figure 3, each of the three fields in
-the structure is constrained.  The first two fields ("Option-Code"
-and "Option-Len") are to be set to constant values (note the
-inconsistency in how these constraints are expressed in the
-description).  However, the third field ("Downstream Source Port")
-can take a value from a constrained set.  This constraint is
-expressed in prose that cannot readily by understood by machine.
+"""   Ambiguous constraints:  The constraints that are enforced on a
+      particular field are often described ambiguously, or in a way that
+      cannot be parsed easily.  In Figure 3, each of the three fields in
+      the structure is constrained.  The first two fields ("Option-Code"
+      and "Option-Len") are to be set to constant values (note the
+      inconsistency in how these constraints are expressed in the
+      description).  However, the third field ("Downstream Source Port")
+      can take a value from a constrained set.  This constraint is
+      expressed in prose that cannot readily by understood by machine.
 """)
         # section-01 -- subsection[0] content[7] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[7].anchor)
@@ -4075,8 +4077,8 @@ expressed in prose that cannot readily by understood by machine.
         if not isinstance(middle.content[1].sections[0].content[8].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[8].content[0].content,
-"""Poor linking between sub-structures:  Protocol data units and other
-structures are often comprised of sub-structures that are defined
+"""   Poor linking between sub-structures:  Protocol data units and other
+      structures are often comprised of sub-structures that are defined
 """)
         # section-01 -- subsection[0] content[8] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[8].anchor)
@@ -4094,10 +4096,10 @@ structures are often comprised of sub-structures that are defined
         if not isinstance(middle.content[1].sections[0].content[9].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[9].content[0].content,
-"""elsewhere, either in the same document, or within another
-document.  Chaining these structures together is essential for
-machine parsing: the parsing process for a protocol data unit is
-only fully expressed if all elements can be parsed.
+"""      elsewhere, either in the same document, or within another
+      document.  Chaining these structures together is essential for
+      machine parsing: the parsing process for a protocol data unit is
+      only fully expressed if all elements can be parsed.
 """)
         # section-01 -- subsection[0] content[9] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[9].anchor)
@@ -4115,13 +4117,13 @@ only fully expressed if all elements can be parsed.
         if not isinstance(middle.content[1].sections[0].content[10].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[10].content[0].content,
-"""Figure 2 highlights the difficulty that machine parsers have in
-chaining structures together.  Two fields ("Stream ID" and "Final
-Size") are described as being encoded as variable-length integers;
-this is a structure described elsewhere in the same document.
-Structured text is required both alongside the definition of the
-containing structure and with the definition of the sub-structure,
-to allow a parser to link the two together.
+"""      Figure 2 highlights the difficulty that machine parsers have in
+      chaining structures together.  Two fields ("Stream ID" and "Final
+      Size") are described as being encoded as variable-length integers;
+      this is a structure described elsewhere in the same document.
+      Structured text is required both alongside the definition of the
+      containing structure and with the definition of the sub-structure,
+      to allow a parser to link the two together.
 """)
         # section-01 -- subsection[0] content[10] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[10].anchor)
@@ -4140,14 +4142,14 @@ to allow a parser to link the two together.
         if not isinstance(middle.content[1].sections[0].content[11].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[0].content[11].content[0].content,
-"""Lack of extension and evolution syntax:  Protocols are often
-specified across multiple documents, either because the protocol
-explicitly includes extension points (e.g., profiles and payload
-format specifications in RTP [RFC3550]) or because definition of a
-protocol data unit has changed and evolved over time.  As a
-result, it is essential that syntax be provided to allow for a
-complete definition of a protocol's parsing process to be
-constructed across multiple documents.
+"""   Lack of extension and evolution syntax:  Protocols are often
+      specified across multiple documents, either because the protocol
+      explicitly includes extension points (e.g., profiles and payload
+      format specifications in RTP [RFC3550]) or because definition of a
+      protocol data unit has changed and evolved over time.  As a
+      result, it is essential that syntax be provided to allow for a
+      complete definition of a protocol's parsing process to be
+      constructed across multiple documents.
 """)
         # section-01 -- subsection[0] content[11] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[0].content[11].anchor)
@@ -4225,16 +4227,16 @@ constructed across multiple documents.
         if not isinstance(middle.content[1].sections[1].content[0].content[0], rfc.Text):
             return
         self.assertEqual(middle.content[1].sections[1].content[0].content[0].content,
-"""A small proportion of IETF standards documents contain structured and
-formal languages, including ABNF [RFC5234], ASN.1 [ASN1], C, CBOR
-[RFC7049], JSON, the TLS presentation language [RFC8446], YANG models
-[RFC7950], and XML.  While this broad range of languages may be
-problematic for the development of tooling to parse specifications,
-these, and other, languages serve a range of different use cases.
-ABNF, for example, is typically used to specify text protocols, while
-ASN.1 is used to specify data structure serialisation.  This document
-specifies a structured language for specifying the parsing of binary
-protocol data units.
+"""   A small proportion of IETF standards documents contain structured and
+   formal languages, including ABNF [RFC5234], ASN.1 [ASN1], C, CBOR
+   [RFC7049], JSON, the TLS presentation language [RFC8446], YANG models
+   [RFC7950], and XML.  While this broad range of languages may be
+   problematic for the development of tooling to parse specifications,
+   these, and other, languages serve a range of different use cases.
+   ABNF, for example, is typically used to specify text protocols, while
+   ASN.1 is used to specify data structure serialisation.  This document
+   specifies a structured language for specifying the parsing of binary
+   protocol data units.
 """)
         # section-01 -- subsection[1] content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
         self.assertIsNone( middle.content[1].sections[1].content[0].anchor)
@@ -4341,7 +4343,7 @@ protocol data units.
         self.assertEqual(middle.content[3].sections[0].name.content[0].content, "PDUs with Fixed and Variable-Width Fields")
         # section-03 -- sub-section[0] content 
         self.assertIsInstance(middle.content[3].sections[0].content, list)
-        self.assertEqual(len(middle.content[3].sections[0].content), 24)
+        self.assertEqual(len(middle.content[3].sections[0].content), 10)
         # section-03 -- sub-section[0] content[0--6] <T> 
         self.assertIsInstance(middle.content[3].sections[0].content[0], rfc.T)
         self.assertIsInstance(middle.content[3].sections[0].content[1], rfc.T)
@@ -4390,22 +4392,504 @@ protocol data units.
         self.assertIsNone( middle.content[3].sections[0].content[7].xmlSpace) 
 
 
-        # section-03 -- sub-section[0] content[8--23] <T> 
+        # section-03 -- sub-section[0] content[8] <T> 
         self.assertIsInstance(middle.content[3].sections[0].content[8], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[9], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[10], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[11], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[12], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[13], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[14], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[15], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[16], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[18], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[19], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[20], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[21], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[22], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[0].content[23], rfc.T)
+        if not isinstance(middle.content[3].sections[0].content[8], rfc.T):
+            return
+        self.assertIsInstance(middle.content[3].sections[0].content[8].content, list)
+        self.assertEqual(len(middle.content[3].sections[0].content[8].content), 1)
+        self.assertIsInstance(middle.content[3].sections[0].content[8].content[0], rfc.Text)
+        if not isinstance(middle.content[3].sections[0].content[8].content[0], rfc.Text):
+            return
+        self.assertEqual(middle.content[3].sections[0].content[8].content[0].content,
+"""   where:
+""")
+
+        # sec-03 sub-section[0] content [9] <DL>
+        self.assertIsInstance( middle.content[3].sections[0].content[9], rfc.DL)
+        if not isinstance( middle.content[3].sections[0].content[9], rfc.DL) : # type-check
+            return
+        # sec-03 sub-section[0] content [9] <DL> content 
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content), 15)
+
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][0].content[0].content, "   Version (V): 4 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[0][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][1].content[0].content, 
+"""  This is a fixed-width field, whose full label
+      is shown in the diagram.  The field's width -- 4 bits -- is given
+      in the label of the description list, separated from the field's
+      label by a colon.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].anchor)
+
+        # sec-03 sub-section[0] content [9] <DL> content [1] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [1] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[1][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[1][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[1][0].content[0].content, "   Internet Header Length (IHL): 4 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[1][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [1] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[1][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [1] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[1][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[1][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[1][1].content[0].content, 
+"""  This is a shorter field, whose
+      full label is too large to be shown in the diagram.  A short label
+      (IHL) is used in the diagram, and this short label is provided, in
+      brackets, after the full label in the description list.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [1] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[1][1].anchor)
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [2] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [2] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[2][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[2][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[2][0].content[0].content, "   Differentiated Services Code Point (DSCP): 6 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[2][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [2] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[2][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [2] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[2][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[2][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[2][1].content[0].content, 
+"""  This is a fixed-
+      width field, as previously discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [2] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[1][1].anchor)
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [3] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [3] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[3][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[3][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[3][0].content[0].content, "   Explicit Congestion Notification (ECN): 2 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[3][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [3] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[3][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [3] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[3][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[3][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[3][1].content[0].content, 
+"""  This is a fixed-
+      width field, as previously discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [3] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[3][1].anchor)
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [4] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [4] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[4][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[4][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[4][0].content[0].content, "   Total Length (TL): 2 bytes.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[4][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [4] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[4][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [4] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[4][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[4][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[4][1].content[0].content, 
+"""  This is a fixed-width field, as
+      previously discussed.  Where fields are an integral number of
+      bytes in size, the field length can be given in bytes rather than
+      in bits.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [4] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[4][1].anchor)
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [5] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [5] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[5][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[5][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[5][0].content[0].content, "   Identification: 2 bytes.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[5][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [5] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[5][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [5] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[5][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[5][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[5][1].content[0].content, 
+"""  This is a fixed-width field, as previously
+      discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [5] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[5][1].anchor)
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [6] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [6] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[6][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[6][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[6][0].content[0].content, "   Flags: 3 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[6][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [6] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[6][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [6] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[6][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[6][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[6][1].content[0].content, 
+"""  This is a fixed-width field, as previously discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [6] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[6][1].anchor)
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [7] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [7] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[7][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[7][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[7][0].content[0].content, "   Fragment Offset: 13 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[7][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [7] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[7][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [7] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[7][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[7][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[7][1].content[0].content, 
+"""  This is a fixed-width field, as previously
+      discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [7] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[7][1].anchor)
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [8] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [8] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[8][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[8][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[8][0].content[0].content, "   Time to Live (TTL): 1 byte.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[8][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [8] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[8][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [8] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[8][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[8][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[8][1].content[0].content, 
+"""  This is a fixed-width field, as
+      previously discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [8] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[8][1].anchor)
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [9] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [9] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[9][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[9][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[9][0].content[0].content, "   Protocol: 1 byte.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[9][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [9] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[9][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [9] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[9][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[9][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[9][1].content[0].content, 
+"""  This is a fixed-width field, as previously
+      discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [9] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[9][1].anchor)
+
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [10] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [10] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[10][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[10][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[10][0].content[0].content, "   Header Checksum: 2 bytes.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[10][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [10] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[10][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [10] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[10][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[10][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[10][1].content[0].content, 
+"""  This is a fixed-width field, as previously
+      discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [10] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[10][1].anchor)
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [11] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [11] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[11][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[11][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[11][0].content[0].content, "   Source Address: 32 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[11][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [11] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[11][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [11] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[11][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[11][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[11][1].content[0].content, 
+"""  This is a fixed-width field, as previously
+      discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [11] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[11][1].anchor)
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [12] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [12] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[12][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[12][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[12][0].content[0].content, "   Destination Address: 32 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[12][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [12] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[12][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [12] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[12][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[12][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[12][1].content[0].content, 
+"""  This is a fixed-width field, as
+      previously discussed.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [12] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[12][1].anchor)
+
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [13] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [13] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[13][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][0].content[0].content, "   Options: (IHL-5)*32 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [13] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[13][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [13] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[13][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[13][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[13][1].content[0].content, 
+"""  This is a variable-length field, whose
+      length is defined by the value of the field with short label IHL
+      (Internet Header Length).  Constraint expressions can be used in
+      place of constant values: the grammar for the expression language
+      is defined in Appendix A.1.  Constraints can include a previously
+      defined field's short or full label, where one has been defined.
+      Short variable-length fields are indicated by "..." instead of a
+      pipe at the end of the row.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [13] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[13][1].anchor)
+
+
+
+
+
+        # sec-03 sub-section[0] content [9] <DL> content [14] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [14] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[14][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[14][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[0].content[9].content[14][0].content[0].content, "   Payload: TL - ((IHL*32)/8) bytes.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[14][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [14] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[14][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [14] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[14][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[9].content[14][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[0].content[9].content[14][1].content[0].content, 
+"""  This is a multi-row variable-
+      length field, constrained by the values of fields TL and IHL.
+      Instead of the "..." notation, ":" is used to indicate that the
+      field is variable-length.  The use of ":" instead of "..."
+      indicates the field is likely to be a longer, multi-row field.
+      However, semantically, there is no difference: these different
+      notations are for the benefit of human readers.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [14] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[14][1].anchor)
+
+        # sec-03 sub-section[0] content [9] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[14][1].anchor)
+        self.assertTrue( middle.content[3].sections[0].content[9].hanging)
+        self.assertEqual( middle.content[3].sections[0].content[9].spacing, "normal")
+
+
+        # sec-03 sub-section[0] content [9] <DL>
+        self.assertIsInstance( middle.content[3].sections[0].content[9], rfc.DL)
+        # sec-03 sub-section[0] content [9] <DL> content 
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content), 15)
+
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0], tuple)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][0].content[0], rfc.Text)
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][0].content[0].content, "   Version (V): 4 bits.")
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][0].anchor)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[0].content[9].content[0][1].content), 1)
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[0].content[9].content[0][1].content[0], rfc.Text)
+        self.assertEqual( middle.content[3].sections[0].content[9].content[0][1].content[0].content, 
+"""  This is a fixed-width field, whose full label
+      is shown in the diagram.  The field's width -- 4 bits -- is given
+      in the label of the description list, separated from the field's
+      label by a colon.
+""")
+        # sec-03 sub-section[0] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[0].content[9].content[0][1].anchor)
+
+        # sec-03 sub-section[0] content [9] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[0].content[9].anchor)
+        self.assertTrue( middle.content[3].sections[0].content[9].hanging) 
+        self.assertEqual( middle.content[3].sections[0].content[9].spacing, "normal") 
 
 
 
@@ -4421,6 +4905,8 @@ protocol data units.
         self.assertIsNone(middle.content[3].sections[0].title)
         self.assertEqual(middle.content[3].sections[0].toc, "default" )
 
+
+
         # section-03 -- sub-section[1]
         self.assertIsInstance(middle.content[3].sections[1], rfc.Section)
         self.assertIsInstance(middle.content[3].sections[1].name, rfc.Name)
@@ -4433,7 +4919,7 @@ protocol data units.
 
         # section-03 -- sub-section[1] content 
         self.assertIsInstance(middle.content[3].sections[1].content, list)
-        self.assertEqual(len(middle.content[3].sections[1].content), 24)
+        self.assertEqual(len(middle.content[3].sections[1].content), 9)
 
         # section-03 -- sub-section[1] sections 
         self.assertIsInstance(middle.content[3].sections[1].sections, list)
@@ -4468,18 +4954,100 @@ protocol data units.
         self.assertIsNone( middle.content[3].sections[1].content[1].width) 
         self.assertIsNone( middle.content[3].sections[1].content[1].xmlSpace) 
 
-        # section-03 -- sub-section[1] anchor, numbered, removeInRFC, title, toc
-        self.assertIsNone(middle.content[3].sections[1].anchor)
-        self.assertTrue(middle.content[3].sections[1].numbered)
-        self.assertFalse(middle.content[3].sections[1].removeInRFC)
-        self.assertIsNone(middle.content[3].sections[1].title)
-        self.assertEqual(middle.content[3].sections[1].toc, "default" )
 
-        # section-03 -- sub-section[0] content[2--5] <T> 
+        # section-03 -- sub-section[0] content[2] <T> 
         self.assertIsInstance(middle.content[3].sections[1].content[2], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[3], rfc.T)
+        if not isinstance(middle.content[3].sections[1].content[2], rfc.T):
+            return
+        self.assertIsInstance(middle.content[3].sections[1].content[2].content, list)
+        self.assertEqual(len(middle.content[3].sections[1].content[2].content), 1)
+        self.assertIsInstance(middle.content[3].sections[1].content[2].content[0], rfc.Text)
+        if not isinstance(middle.content[3].sections[1].content[2].content[0], rfc.Text):
+            return
+        self.assertEqual(middle.content[3].sections[1].content[2].content[0].content,
+"""   where:
+""")
+
+
+
+        # sec-03 sub-section[1] content [3] <DL>
+        self.assertIsInstance( middle.content[3].sections[1].content[3], rfc.DL)
+        if not isinstance( middle.content[3].sections[1].content[3], rfc.DL) : # type-check
+            return
+        # sec-03 sub-section[1] content [3] <DL> content 
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[3].content), 1)
+
+        # sec-03 sub-section[1] content [3] <DL> content [1] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0], tuple)
+        # sec-03 sub-section[1] content [3] <DL> content [1] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[3].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[3].content[0][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[3].content[0][0].content[0].content, "   SSRC: 32 bits.")
+        self.assertIsNone( middle.content[3].sections[1].content[3].content[0][0].anchor)
+        # sec-03 sub-section[1] content [3] <DL> content [1] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[3].content[0][1].content), 1)
+        # sec-03 sub-section[1] content [3] <DL> content [1] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[1].content[3].content[0][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[3].content[0][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[3].content[0][1].content[0].content, 
+"""  This is a fixed-width field, as described previously.
+""")
+
+
+        # sec-03 sub-section[1] content [3] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[1].content[3].anchor)
+        self.assertTrue( middle.content[3].sections[1].content[3].hanging) 
+        self.assertEqual( middle.content[3].sections[1].content[3].spacing, "normal") 
+
+
+        # section-03 -- sub-section[0] content[4] <T> 
         self.assertIsInstance(middle.content[3].sections[1].content[4], rfc.T)
+        if not isinstance(middle.content[3].sections[1].content[4], rfc.T):
+            return
+        self.assertIsInstance(middle.content[3].sections[1].content[4].content, list)
+        self.assertEqual(len(middle.content[3].sections[1].content[4].content), 1)
+        self.assertIsInstance(middle.content[3].sections[1].content[4].content[0], rfc.Text)
+        if not isinstance(middle.content[3].sections[1].content[4].content[0], rfc.Text):
+            return
+        self.assertEqual(middle.content[3].sections[1].content[4].content[0].content,
+"""   The following example shows how a Source Identifier can be referenced
+   in the description of an RTP Data Packet.  It also shows how the
+   presence of some fields in a format may be dependent on the values of
+   an earlier field.
+""")
+        # section-03 -- sub-section[0] content[4] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[4].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[4].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[4].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[4].keepWithPrevious)
+
+        # section-03 -- sub-section[1] content[5] <T> 
         self.assertIsInstance(middle.content[3].sections[1].content[5], rfc.T)
+        if not isinstance(middle.content[3].sections[1].content[5], rfc.T):
+            return
+        self.assertIsInstance(middle.content[3].sections[1].content[5].content, list)
+        self.assertEqual(len(middle.content[3].sections[1].content[5].content), 1)
+        self.assertIsInstance(middle.content[3].sections[1].content[5].content[0], rfc.Text)
+        if not isinstance(middle.content[3].sections[1].content[5].content[0], rfc.Text):
+            return
+        self.assertEqual(middle.content[3].sections[1].content[5].content[0].content,
+"""   An RTP Data Packet is formatted as follows:
+""")
+        # section-03 -- sub-section[0] content[4] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[5].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[5].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[5].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[5].keepWithPrevious)
+
+
 
         # section-03 -- sub-section[1] content[6] <Artwork> 
         self.assertIsInstance(middle.content[3].sections[1].content[6], rfc.Artwork)
@@ -4521,24 +5089,285 @@ protocol data units.
         self.assertIsNone( middle.content[3].sections[1].content[6].xmlSpace) 
 
 
-        # section-03 -- sub-section[0] content[7--23] <T> 
+        # section-03 -- sub-section[1] content[7] <T> 
         self.assertIsInstance(middle.content[3].sections[1].content[7], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[8], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[9], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[10], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[11], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[12], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[13], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[14], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[15], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[16], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[17], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[18], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[19], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[20], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[21], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[22], rfc.T)
-        self.assertIsInstance(middle.content[3].sections[1].content[23], rfc.T)
+        if not isinstance(middle.content[3].sections[1].content[7], rfc.T):
+            return
+        self.assertIsInstance(middle.content[3].sections[1].content[7].content, list)
+        self.assertEqual(len(middle.content[3].sections[1].content[7].content), 1)
+        self.assertIsInstance(middle.content[3].sections[1].content[7].content[0], rfc.Text)
+        if not isinstance(middle.content[3].sections[1].content[7].content[0], rfc.Text):
+            return
+        self.assertEqual(middle.content[3].sections[1].content[7].content[0].content,
+"""   where:
+""")
+        # section-03 -- sub-section[1] content[7] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[7].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[7].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[7].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[7].keepWithPrevious)
+
+
+        # section-03 -- sub-section[1] content[8] <DL> 
+        self.assertIsInstance(middle.content[3].sections[1].content[8], rfc.DL)
+        if not isinstance( middle.content[3].sections[1].content[8], rfc.DL) : # type-check
+            return
+        # sec-03 sub-section[1] content [8] <DL> content 
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content), 14)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [0] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [0] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[0][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[0][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[8].content[0][0].content[0].content, "   Version (V): 2 bits.")
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[0][0].anchor)
+        # sec-03 sub-section[1] content [8] <DL> content [0] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[0][1].content), 1)
+        # sec-03 sub-section[1] content [8] <DL> content [0] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[0][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[0][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[0][1].content[0].content, 
+"""  This is a fixed-width field, as described
+      previously.
+""")
+        # sec-03 sub-section[1] content [9] <DL> content [0] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[0][1].anchor)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [1] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [1] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[1][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[1][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[8].content[1][0].content[0].content, "   Padding (P): 1 bit.")
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[1][0].anchor)
+        # sec-03 sub-section[1] content [8] <DL> content [1] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[1][1].content), 1)
+        # sec-03 sub-section[1] content [8] <DL> content [1] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[1][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[1][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[1][1].content[0].content, 
+"""  This is a fixed-width field, as described
+      previously.
+""")
+        # sec-03 sub-section[1] content [9] <DL> content [1] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[1][1].anchor)
+
+        # sec-03 sub-section[1] content [3] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[1].content[8].anchor)
+        self.assertTrue( middle.content[3].sections[1].content[8].hanging) 
+        self.assertEqual( middle.content[3].sections[1].content[8].spacing, "normal") 
+
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [2] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [2] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[8][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[8][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[8].content[8][0].content[0].content, "   Synchronization Source identifier: 1 Source Identifier.")
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[8][0].anchor)
+        # sec-03 sub-section[1] content [8] <DL> content [2] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[8][1].content), 1)
+        # sec-03 sub-section[1] content [8] <DL> content [2] <Tuple<DL,DD>> [1] <DD> content[0] <Text>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[8][1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[8][1].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[8][1].content[0].content, 
+"""  This is a
+      field whose structure is a previously defined PDU format (Source
+      Identifier).  To indicate this, the width of the field is
+      expressed in terms of cross-referenced structure.  When used in
+      constraint expressions, PDU names refer to the length of that PDU
+      structure.
+""")
+        # sec-03 sub-section[1] content [9] <DL> content [8] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[8][1].anchor)
+
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[9][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[8].content[9][0].content[0].content, "   Contributing Source identifiers: CC Source Identifier.")
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][0].anchor)
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[9][1].content), 2)
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [1] <DD> content[0] <T>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[0], rfc.T)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[0], rfc.T): # type-check
+            return
+
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[0].content, list)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[0].content, list): # type-check
+            return
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[9][1].content[0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[0].content[0], rfc.Text): # type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[9][1].content[0].content[0].content, 
+"""  Where a field
+      is comprised of a sequence of previously defined structures,
+      square brackets can be used to indicate this in the diagram.  The
+      length of the sequence can be defined using the constraint
+      expression grammar as described earlier.  Where the length is
+      unknown, the type of each element of the sequence must be given in
+      square brackets.
+""")
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [1] <DD> content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][1].content[0].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][1].content[0].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[9][1].content[0].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[9][1].content[0].keepWithPrevious)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [1] <DD> content[1] <T>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[1], rfc.T)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[1], rfc.T): # type-check
+            return
+
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[1].content, list)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[1].content, list): # type-check
+            return
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[9][1].content[1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[9][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[9][1].content[1].content[0], rfc.Text): # type-check 
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[9][1].content[1].content[0].content, 
+"""      In this example, both a PDU name (Source Identifier) and a field
+      name (CC) are used in the constraint expression.  The PDU name
+      refers to the length of the PDU, while the field name refers to
+      the value of the field.  This is possible because field names
+      cannot be the same as previously defined PDU names.
+""")
+
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [1] <DD> content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][1].content[1].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][1].content[1].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[9][1].content[1].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[9][1].content[1].keepWithPrevious)
+
+        # sec-03 sub-section[1] content [9] <DL> content [9] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[9][1].anchor)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [9] <Tuple<DL,DD>> [0] <DT>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][0], rfc.DT)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][0].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[10][0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][0].content[0], rfc.Text): # type-check
+             return 
+        self.assertEqual( middle.content[3].sections[1].content[8].content[10][0].content[0].content, "   Header Extension: 32 bits; present only when X == 1.")
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][0].anchor)
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>> [1] <DD>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1], rfc.DD)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content, list)
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[10][1].content), 2)
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>> [1] <DD> content[0] <T>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[0], rfc.T)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[0], rfc.T): # type-check
+            return
+
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[0].content, list)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[0].content, list): # type-check
+            return
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[10][1].content[0].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[0].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[0].content[0], rfc.Text): # type-check
+             return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[10][1].content[0].content[0].content, 
+"""  This is a field
+      whose presence is predicated on an expression given using the
+      constraint expression grammar described earlier.  Optional fields
+      can be of any previously defined format (e.g., fixed- or variable-
+      width).  Optional fields are indicated by the presence of ";
+      present only when [expr]." at the end of the definition term
+      (i.e., the text contained within the <dt> tag).
+""")
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>> [1] <DD> content[0] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][1].content[0].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][1].content[0].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[10][1].content[0].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[10][1].content[0].keepWithPrevious)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>> [1] <DD> content[1] <T>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[1], rfc.T)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[1], rfc.T): # type-check
+            return
+
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[1].content, list)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[1].content, list): # type-check
+            return
+        self.assertEqual( len(middle.content[3].sections[1].content[8].content[10][1].content[1].content), 1)
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[10][1].content[1].content[0], rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[8].content[10][1].content[1].content[0], rfc.Text): #type-check
+            return
+        self.assertEqual( middle.content[3].sections[1].content[8].content[10][1].content[1].content[0].content, 
+"""      [Note that this example deviates from the format as described in
+      [RFC3550].  As specified in that document, the Header Extension
+      would be a cross-referenced structure.  This is not shown here for
+      brevity.]
+""")
+
+        # sec-03 sub-section[1] content [8] <DL> content [10] <Tuple<DL,DD>> [1] <DD> content[1] <T> anchor, hangText, keepWithNext, keepWithPrevious
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][1].content[1].anchor)
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][1].content[1].hangText)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[10][1].content[1].keepWithNext)
+        self.assertFalse ( middle.content[3].sections[1].content[8].content[10][1].content[1].keepWithPrevious)
+
+        # sec-03 sub-section[1] content [9] <DL> content [9] <Tuple<DL,DD>> [0] <DD> anchor
+        self.assertIsNone( middle.content[3].sections[1].content[8].content[10][1].anchor)
+
+
+        # sec-03 sub-section[1] content [8] <DL> content [11] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[11], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [12] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[12], tuple)
+        # sec-03 sub-section[1] content [8] <DL> content [13] <Tuple<DL,DD>>
+        self.assertIsInstance( middle.content[3].sections[1].content[8].content[13], tuple)
+
+        # sec-03 sub-section[1] content [3] <DL> anchor, hanging, spacing
+        self.assertIsNone( middle.content[3].sections[1].content[8].anchor)
+        self.assertTrue( middle.content[3].sections[1].content[8].hanging) 
+        self.assertEqual( middle.content[3].sections[1].content[8].spacing, "normal") 
+
+
+
 
         # section-03 -- sub-section[1] anchor, numbered, removeInRFC, title, toc
         self.assertIsNone(middle.content[3].sections[1].anchor)
@@ -4546,6 +5375,7 @@ protocol data units.
         self.assertFalse(middle.content[3].sections[1].removeInRFC)
         self.assertIsNone(middle.content[3].sections[1].title)
         self.assertEqual(middle.content[3].sections[1].toc, "default" )
+
 
 
         # section-03 -- sub-section[2]

--- a/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
+++ b/tests/test_parse_draft_mcquistin_augmented_ascii_diagrams.py
@@ -3609,14 +3609,10 @@ diagram.
         self.assertIsInstance( middle.content[0].content[2], rfc.Artwork)
         if not isinstance( middle.content[0].content[2], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[0].content[2].content, list)
-        if not isinstance( middle.content[0].content[2].content, list):
+        self.assertIsInstance( middle.content[0].content[2].content, rfc.Text)
+        if not isinstance( middle.content[0].content[2].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[0].content[2].content), 1)
-        self.assertIsInstance( middle.content[0].content[2].content[0], rfc.Text)
-        if not isinstance( middle.content[0].content[2].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[0].content[2].content[0].content,
+        self.assertEqual( middle.content[0].content[2].content.content,
 """:    0                   1                   2                   3
 :    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 :   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -3863,14 +3859,10 @@ to the relatively incremental approach proposed here.
         self.assertIsInstance( middle.content[1].sections[0].content[0], rfc.Artwork)
         if not isinstance( middle.content[1].sections[0].content[0], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[1].sections[0].content[0].content, list)
-        if not isinstance( middle.content[1].sections[0].content[0].content, list):
+        self.assertIsInstance( middle.content[1].sections[0].content[0].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[0].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[1].sections[0].content[0].content), 1)
-        self.assertIsInstance( middle.content[1].sections[0].content[0].content[0], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[0].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[1].sections[0].content[0].content[0].content,
+        self.assertEqual( middle.content[1].sections[0].content[0].content.content,
 """:   The RESET_STREAM frame is as follows:
 :
 :    0                   1                   2                   3
@@ -4167,14 +4159,10 @@ constructed across multiple documents.
         self.assertIsInstance(middle.content[1].sections[0].content[12], rfc.Artwork)
         if not isinstance(middle.content[1].sections[0].content[12], rfc.Artwork):
             return
-        self.assertIsInstance( middle.content[1].sections[0].content[12].content, list)
-        if not isinstance( middle.content[1].sections[0].content[12].content, list):
+        self.assertIsInstance( middle.content[1].sections[0].content[12].content, rfc.Text)
+        if not isinstance( middle.content[1].sections[0].content[12].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[1].sections[0].content[12].content), 1)
-        self.assertIsInstance( middle.content[1].sections[0].content[12].content[0], rfc.Text)
-        if not isinstance( middle.content[1].sections[0].content[12].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[1].sections[0].content[12].content[0].content,
+        self.assertEqual( middle.content[1].sections[0].content[12].content.content,
 """:   The format of the "Relay Source Port Option" is shown below:
 :
 :    0                   1                   2                   3
@@ -4366,14 +4354,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[0].content[7], rfc.Artwork)
         if not isinstance(middle.content[3].sections[0].content[7], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[0].content[7].content, list)
-        if not isinstance(middle.content[3].sections[0].content[7].content, list):
+        self.assertIsInstance( middle.content[3].sections[0].content[7].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[0].content[7].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[0].content[7].content), 1)
-        self.assertIsInstance( middle.content[3].sections[0].content[7].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[0].content[7].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[0].content[7].content[0].content, 
+        self.assertEqual( middle.content[3].sections[0].content[7].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4463,14 +4447,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[1].content[1], rfc.Artwork)
         if not isinstance(middle.content[3].sections[1].content[1], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[1].content[1].content, list)
-        if not isinstance(middle.content[3].sections[1].content[1].content, list):
+        self.assertIsInstance( middle.content[3].sections[1].content[1].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[1].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[1].content[1].content), 1)
-        self.assertIsInstance( middle.content[3].sections[1].content[1].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[1].content[1].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[1].content[1].content[0].content, 
+        self.assertEqual( middle.content[3].sections[1].content[1].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4505,14 +4485,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[1].content[6], rfc.Artwork)
         if not isinstance(middle.content[3].sections[1].content[6], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[1].content[6].content, list)
-        if not isinstance(middle.content[3].sections[1].content[6].content, list):
+        self.assertIsInstance( middle.content[3].sections[1].content[6].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[1].content[6].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[1].content[6].content), 1)
-        self.assertIsInstance( middle.content[3].sections[1].content[6].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[1].content[6].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[1].content[6].content[0].content, 
+        self.assertEqual( middle.content[3].sections[1].content[6].content.content, 
 """0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4594,14 +4570,10 @@ protocol data units.
         self.assertIsInstance(middle.content[3].sections[2].content[2], rfc.Artwork)
         if not isinstance(middle.content[3].sections[2].content[2], rfc.Artwork):
             return
-        self.assertIsInstance(middle.content[3].sections[2].content[2].content, list)
-        if not isinstance(middle.content[3].sections[2].content[2].content, list):
+        self.assertIsInstance( middle.content[3].sections[2].content[2].content, rfc.Text)
+        if not isinstance( middle.content[3].sections[2].content[2].content, rfc.Text):
             return
-        self.assertEqual( len(middle.content[3].sections[2].content[2].content), 1)
-        self.assertIsInstance( middle.content[3].sections[2].content[2].content[0], rfc.Text)
-        if not isinstance( middle.content[3].sections[2].content[2].content[0], rfc.Text):
-            return
-        self.assertEqual( middle.content[3].sections[2].content[2].content[0].content, 
+        self.assertEqual( middle.content[3].sections[2].content[2].content.content, 
 """0                   1
 0 1 2 3 4 5 6 7 8 9 0 1 2 3
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+


### PR DESCRIPTION

1. Initial parsing will only differentiate between and elements.
2. Recursive DOM walker used to identify and transform every element.
3. Postprocessing phase will convert PDU field descriptions into lists of 
    (dt,dd) tags   to make it as similar to the xml processing pipeline as possible.
4. Top level PDU  parsing made more graceful by incorporating space and line-feed. 

